### PR TITLE
refactor: remove deprecated instrumentationHook

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,9 +3,6 @@ const { withSentryConfig } = require('@sentry/nextjs');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    instrumentationHook: true,
-  },
   // Prototype settings - remove for production
   typescript: {
     ignoreBuildErrors: true,


### PR DESCRIPTION
## Summary
- remove deprecated `experimental.instrumentationHook` from Next.js config

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb48d1dd8832f82e4f254b9d9c91f