### PR TITLE
Export ExceptionRule interface

### DIFF
--- a/src/rules/__tests__/exception.engine.test.ts
+++ b/src/rules/__tests__/exception.engine.test.ts
@@ -1,74 +1,90 @@
-import { ExceptionRule, ExceptionEngine } from '../exception.engine';
+import { ExceptionRule } from '../exception.engine';
 
 describe('ExceptionEngine', () => {
   describe('Exception Rules', () => {
-    it('should detect rate mismatches correctly', () => {
+    it('should detect rate mismatches correctly', async () => {
       const rateRule: ExceptionRule = {
         id: 'rate-mismatch',
         name: 'Rate Mismatch Detection',
-        description: 'Expected rate differs from actual',
-        evaluate: (context: any) => {
-          const expectedRate = context.expectedRate;
-          const actualRate = context.actualRate;
-          return actualRate !== expectedRate;
+        check: async (context: any) => {
+          const { expectedRate, actualRate } = context;
+          if (expectedRate !== actualRate) {
+            return {
+              type: 'rate-mismatch',
+              severity: 'high',
+              description: 'Expected rate differs from actual',
+              suggestedAction: 'Review and update rate policy',
+            };
+          }
+          return null;
         },
-        severity: 'high',
-        suggestedAction: 'Review and update rate policy'
       };
 
       const context = { expectedRate: 150, actualRate: 100 };
-      expect(rateRule.evaluate(context)).toBe(true);
+      const result = await rateRule.check(context);
+      expect(result).not.toBeNull();
     });
 
-    it('should detect budget breaches at 90% threshold', () => {
+    it('should detect budget breaches at 90% threshold', async () => {
       const budgetRule: ExceptionRule = {
         id: 'budget-breach',
         name: 'Budget Breach Detection',
-        description: 'Project exceeds 90% of budget',
-        evaluate: (context: any) => {
-          const budgetUsed = context.hoursUsed;
-          const budgetTotal = context.budgetTotal;
-          const percentage = (budgetUsed / budgetTotal) * 100;
-          return percentage >= 90;
+        check: async (context: any) => {
+          const { hoursUsed, budgetTotal } = context;
+          const percentage = (hoursUsed / budgetTotal) * 100;
+          if (percentage >= 90) {
+            return {
+              type: 'budget-breach',
+              severity: 'high',
+              description: 'Project exceeds 90% of budget',
+              suggestedAction: 'Alert PM and review scope',
+            };
+          }
+          return null;
         },
-        severity: 'high',
-        suggestedAction: 'Alert PM and review scope'
       };
 
       const overBudget = { hoursUsed: 95, budgetTotal: 100 };
       const underBudget = { hoursUsed: 80, budgetTotal: 100 };
-      
-      expect(budgetRule.evaluate(overBudget)).toBe(true);
-      expect(budgetRule.evaluate(underBudget)).toBe(false);
+
+      await expect(budgetRule.check(overBudget)).resolves.not.toBeNull();
+      await expect(budgetRule.check(underBudget)).resolves.toBeNull();
     });
 
-    it('should detect billable/non-billable conflicts', () => {
+    it('should detect billable/non-billable conflicts', async () => {
       const conflictRule: ExceptionRule = {
         id: 'billable-conflict',
         name: 'Billable Conflict Detection',
-        description: 'Task category conflicts with billable flag',
-        evaluate: (context: any) => {
-          const taskCategory = context.taskCategory;
-          const isBillable = context.isBillable;
-          
-          // Non-billable tasks marked as billable
-          if (taskCategory === 'non-billable' && isBillable) return true;
-          // Billable tasks marked as non-billable  
-          if (taskCategory === 'billable' && !isBillable) return true;
-          
-          return false;
+        check: async (context: any) => {
+          const { taskCategory, isBillable } = context;
+          if (taskCategory === 'non-billable' && isBillable) {
+            return {
+              type: 'billable-conflict',
+              severity: 'medium',
+              description: 'Task category conflicts with billable flag',
+              suggestedAction: 'Correct task categorization',
+            };
+          }
+          if (taskCategory === 'billable' && !isBillable) {
+            return {
+              type: 'billable-conflict',
+              severity: 'medium',
+              description: 'Task category conflicts with billable flag',
+              suggestedAction: 'Correct task categorization',
+            };
+          }
+          return null;
         },
-        severity: 'medium',
-        suggestedAction: 'Correct task categorization'
       };
 
       const conflict1 = { taskCategory: 'non-billable', isBillable: true };
       const conflict2 = { taskCategory: 'billable', isBillable: false };
       const noConflict = { taskCategory: 'billable', isBillable: true };
-      
-      expect(conflictRule.evaluate(conflict1)).toBe(true);
-      expect(conflictRule.evaluate(conflict2)).toBe(true);
-      expect(conflictRule.evaluate(noConflict)).toBe(false);
+
+      await expect(conflictRule.check(conflict1)).resolves.not.toBeNull();
+      await expect(conflictRule.check(conflict2)).resolves.not.toBeNull();
+      await expect(conflictRule.check(noConflict)).resolves.toBeNull();
     });
   });
 });
+

--- a/src/rules/exception.engine.ts
+++ b/src/rules/exception.engine.ts
@@ -303,7 +303,7 @@ export class ExceptionEngine {
   }
 }
 
-interface ExceptionRule {
+export interface ExceptionRule {
   id: string;
   name: string;
   check: (entry: any) => Promise<{


### PR DESCRIPTION
## Summary
- export ExceptionRule interface from exception engine
- update tests to import and use the exported interface

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb7ba80c4832fb7d93902663f4ebb