### PR TITLE
chore: type SQL queries in profitability service

### DIFF
--- a/src/models/database.ts
+++ b/src/models/database.ts
@@ -1,4 +1,4 @@
-import { Pool } from 'pg';
+import { Pool, QueryResult } from 'pg';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -8,9 +8,12 @@ export const pool = new Pool({
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 
-export async function query(text: string, params?: any[]) {
+export async function query<T = any>(
+  text: string,
+  params?: any[]
+): Promise<QueryResult<T>> {
   const start = Date.now();
-  const res = await pool.query(text, params);
+  const res = await pool.query<T>(text, params);
   const duration = Date.now() - start;
   console.log('Executed query', { text, duration, rows: res.rowCount });
   return res;


### PR DESCRIPTION
## Summary
- remove unused imports from profitability service
- add interfaces for SQL results
- use generics to type database queries

## Testing
- `npm run typecheck` (fails: Property 'startTransaction' does not exist on type...)
- `npm test`
- `npm run lint` (fails: react/no-unescaped-entities in app/error.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68bdb7c7fea8832fbfff2db3994b546e