### PR TITLE
Enforce build checks and guard Sentry integration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,41 +1,41 @@
-const { withSentryConfig } = require('@sentry/nextjs');
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
     instrumentationHook: true,
   },
-  // Prototype settings - remove for production
-  typescript: {
-    ignoreBuildErrors: true,
-  },
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
-}
+};
 
-module.exports = withSentryConfig(
-  nextConfig,
-  {
-    // Sentry Webpack Plugin Options
-    silent: true,
-    org: process.env.SENTRY_ORG,
-    project: process.env.SENTRY_PROJECT,
-    
-    // Upload source maps during build
-    widenClientFileUpload: true,
-    
-    // Transpile SDK for compatibility
-    transpileClientSDK: true,
-    
-    // Hide source maps from public
-    hideSourceMaps: true,
-    
-    // Disable server source map uploading (optional)
-    disableLogger: true,
-    
-    // Automatically instrument API routes
-    automaticVercelMonitors: true,
-  }
-);
+const sentryWebpackPluginOptions = {
+  // Sentry Webpack Plugin Options
+  silent: true,
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+
+  // Upload source maps during build
+  widenClientFileUpload: true,
+
+  // Transpile SDK for compatibility
+  transpileClientSDK: true,
+
+  // Hide source maps from public
+  hideSourceMaps: true,
+
+  // Disable server source map uploading (optional)
+  disableLogger: true,
+
+  // Automatically instrument API routes
+  automaticVercelMonitors: true,
+};
+
+const hasSentryEnv =
+  process.env.SENTRY_AUTH_TOKEN &&
+  process.env.SENTRY_ORG &&
+  process.env.SENTRY_PROJECT;
+
+module.exports = hasSentryEnv
+  ? require('@sentry/nextjs').withSentryConfig(
+      nextConfig,
+      sentryWebpackPluginOptions
+    )
+  : nextConfig;


### PR DESCRIPTION
## Summary
- remove prototype TypeScript/ESLint build ignores from Next.js config
- activate Sentry Webpack plugin only when required environment variables are present

## Testing
- `npm test`
- `npm run lint` *(fails: Unescaped entities, ban-ts-comment, no-html-link-for-pages, and many warnings)*
- `npm run typecheck` *(fails: missing Exception.createdAt, missing Sentry methods)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb93d9cd8832f906d4746faa3b781