### PR TITLE
chore(tsconfig): use esnext module with bundler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "typecheck": "tsc --noEmit",
+    "build:server": "tsc",
     "migrate": "tsx scripts/migrate.ts",
     "api-dev": "tsx watch src/index.ts",
     "lighthouse": "lhci autorun",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "esnext",
     "lib": [
       "ES2022",
       "DOM"
     ],
     "jsx": "preserve",
-    "outDir": "./dist",
-    "rootDir": "./",
+    "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -17,14 +17,13 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "types": [
       "node",
       "jest"
     ],
     "allowJs": true,
-    "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
     "plugins": [
@@ -34,9 +33,7 @@
     ]
   },
   "include": [
-    "api/**/*.ts",
-    "src/**/*.ts",
-    ".next/types/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
     "node_modules",
@@ -44,6 +41,7 @@
     "tests",
     "**/*.test.ts",
     "**/*.spec.ts",
-    "**/__tests__/**"
+    "**/__tests__/**",
+    ".next"
   ]
 }


### PR DESCRIPTION
## Summary
- compile TS using ESNext modules and bundler resolution with src/dist structure
- add build:server script and move type checking to tsc --noEmit

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc0d5cd4832fa291dff89d505711