### PR TITLE
refactor: centralize sentry init

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,49 +1,33 @@
+async function initSentry(runtime: 'node' | 'edge') {
+  const Sentry = await import('@sentry/nextjs');
+
+  const options = {
+    dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+    tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+    environment: process.env.NODE_ENV,
+    beforeSend(event, hint) {
+      if (process.env.NODE_ENV === 'development' && !process.env.SENTRY_DEBUG) {
+        return null;
+      }
+
+      return event;
+    },
+  };
+
+  const runtimeOptions = runtime === 'node' ? {} : {};
+
+  Sentry.init({
+    ...options,
+    ...runtimeOptions,
+  });
+}
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const Sentry = await import('@sentry/nextjs');
-    
-    Sentry.init({
-      dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-      
-      // Performance Monitoring
-      tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
-      
-      // Environment
-      environment: process.env.NODE_ENV,
-      
-      // Filtering
-      beforeSend(event, hint) {
-        // Don't send events in development unless explicitly enabled
-        if (process.env.NODE_ENV === 'development' && !process.env.SENTRY_DEBUG) {
-          return null;
-        }
-        
-        return event;
-      },
-    });
+    await initSentry('node');
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {
-    const Sentry = await import('@sentry/nextjs');
-    
-    Sentry.init({
-      dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
-      
-      // Performance Monitoring
-      tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
-      
-      // Environment
-      environment: process.env.NODE_ENV,
-      
-      // Filtering
-      beforeSend(event, hint) {
-        // Don't send events in development unless explicitly enabled
-        if (process.env.NODE_ENV === 'development' && !process.env.SENTRY_DEBUG) {
-          return null;
-        }
-        
-        return event;
-      },
-    });
+    await initSentry('edge');
   }
 }


### PR DESCRIPTION
## Summary
- DRY up Sentry setup in instrumentation
- Provide initSentry helper handling shared options

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, @typescript-eslint/ban-ts-comment, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc12454c832fa3ab4b55e8e07256