### PR TITLE
build: add API TypeScript build configuration and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "typecheck": "tsc --noEmit",
     "migrate": "tsx scripts/migrate.ts",
     "api-dev": "tsx watch src/index.ts",
+    "build:api": "tsc -p tsconfig.api.json",
+    "api": "npm run build:api && node dist/src/index.js",
     "lighthouse": "lhci autorun",
     "audit": "npm audit --audit-level=moderate",
     "analyze": "ANALYZE=true next build"

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
## Summary
- add tsconfig.api.json to emit compiled API to `dist`
- add `build:api` and production `api` script to compile before launching Express server

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, no-html-link-for-pages, and other lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc1a963c832f8a3229332564247a