### PR TITLE
chore: relax lighthouse CI thresholds

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,12 +1,11 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'npm run build && npm run start',
+      startServerCommand: 'next start',
       startServerReadyPattern: 'ready on',
       startServerReadyTimeout: 30000,
       url: [
-        'http://localhost:3000/',
-        'http://localhost:3000/api/health'
+        'http://localhost:3000/'
       ],
       numberOfRuns: 3,
       settings: {
@@ -19,18 +18,18 @@ module.exports = {
     assert: {
       preset: 'lighthouse:recommended',
       assertions: {
-        'categories:performance': ['error', { minScore: 0.85 }],
-        'categories:accessibility': ['error', { minScore: 0.90 }],
-        'categories:best-practices': ['error', { minScore: 0.90 }],
-        'categories:seo': ['error', { minScore: 0.90 }],
-        'categories:pwa': ['warn', { minScore: 0.50 }],
+        'categories:performance': ['error', { minScore: 0.75 }],
+        'categories:accessibility': ['error', { minScore: 0.85 }],
+        'categories:best-practices': ['error', { minScore: 0.85 }],
+        'categories:seo': ['error', { minScore: 0.85 }],
+        'categories:pwa': ['warn', { minScore: 0.40 }],
         
         // Specific metrics thresholds
-        'first-contentful-paint': ['error', { maxNumericValue: 2000 }],
-        'largest-contentful-paint': ['error', { maxNumericValue: 2500 }],
-        'cumulative-layout-shift': ['error', { maxNumericValue: 0.1 }],
-        'total-blocking-time': ['error', { maxNumericValue: 300 }],
-        'interactive': ['error', { maxNumericValue: 3800 }],
+        'first-contentful-paint': ['error', { maxNumericValue: 3000 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 3500 }],
+        'cumulative-layout-shift': ['error', { maxNumericValue: 0.2 }],
+        'total-blocking-time': ['error', { maxNumericValue: 500 }],
+        'interactive': ['error', { maxNumericValue: 5000 }],
         
         // Accessibility checks
         'color-contrast': 'error',


### PR DESCRIPTION
## Summary
- use `next start` for Lighthouse CI server and assume build happens beforehand
- audit root page only and remove unused health endpoint
- relax Lighthouse assertion thresholds for early development

## Testing
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities, @typescript-eslint/ban-ts-comment, ...)*
- `npm run build` *(fails: react/no-unescaped-entities, @typescript-eslint/ban-ts-comment, ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc1c7c94832faa3635715f527f03