### PR TITLE
refactor: strengthen typing across connectors and rules

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -164,7 +164,7 @@ router.post('/profitability/calculate', async (req: Request, res: Response) => {
 router.get('/profitability/portfolio/:month', async (req: Request, res: Response) => {
   try {
     const metrics = await profitabilityService.getPortfolioProfitability(
-      new Date(req.params.month)
+      new Date(req.params.month!)
     );
     res.json(metrics);
   } catch (error) {
@@ -177,10 +177,10 @@ router.get('/profitability/portfolio/:month', async (req: Request, res: Response
 router.get('/profitability/trend/:clientId', async (req: Request, res: Response) => {
   try {
     const { months = 6 } = req.query;
-    const trend = await profitabilityService.getClientProfitabilityTrend(
-      req.params.clientId,
-      Number(months)
-    );
+      const trend = await profitabilityService.getClientProfitabilityTrend(
+        req.params.clientId!,
+        Number(months)
+      );
     res.json(trend);
   } catch (error) {
     console.error('Trend error:', error);
@@ -209,12 +209,12 @@ router.post('/exceptions/:id/review', async (req: Request, res: Response) => {
     
     if (action === 'approve') {
       await exceptionEngine.approveException(
-        req.params.id,
+        req.params.id!,
         userId,
         helpdeskTicketId
       );
     } else if (action === 'reject') {
-      await exceptionEngine.rejectException(req.params.id, userId);
+      await exceptionEngine.rejectException(req.params.id!, userId);
     } else {
       return res.status(400).json({ error: 'Invalid action' });
     }
@@ -262,10 +262,10 @@ router.post('/export/csv', async (req: Request, res: Response) => {
 router.get('/budget/:projectId', async (req: Request, res: Response) => {
   try {
     const { month = new Date() } = req.query;
-    const budgetData = await exportService.getBudgetVsBurn(
-      req.params.projectId,
-      new Date(month as string)
-    );
+      const budgetData = await exportService.getBudgetVsBurn(
+        req.params.projectId!,
+        new Date(month as string)
+      );
     res.json(budgetData);
   } catch (error) {
     console.error('Budget error:', error);
@@ -277,10 +277,10 @@ router.get('/budget/:projectId', async (req: Request, res: Response) => {
 router.get('/report/monthly/:clientId', async (req: Request, res: Response) => {
   try {
     const { month = new Date() } = req.query;
-    const report = await exportService.getMonthlyReport(
-      req.params.clientId,
-      new Date(month as string)
-    );
+      const report = await exportService.getMonthlyReport(
+        req.params.clientId!,
+        new Date(month as string)
+      );
     res.json(report);
   } catch (error) {
     console.error('Report error:', error);
@@ -302,10 +302,10 @@ router.get('/clients', async (req: Request, res: Response) => {
 // Projects endpoints
 router.get('/projects/:clientId', async (req: Request, res: Response) => {
   try {
-    const result = await query(
-      'SELECT * FROM projects WHERE client_id = $1 AND is_active = true ORDER BY name',
-      [req.params.clientId]
-    );
+      const result = await query(
+        'SELECT * FROM projects WHERE client_id = $1 AND is_active = true ORDER BY name',
+        [req.params.clientId!]
+      );
     res.json(result.rows);
   } catch (error) {
     console.error('Projects error:', error);

--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -1,5 +1,13 @@
 import axios, { AxiosInstance } from 'axios';
-import { HarvestTimeEntry } from '../types';
+import {
+  HarvestAPITimeEntry,
+  HarvestClient,
+  HarvestProject,
+  HarvestProjectBudget,
+  HarvestTask,
+  HarvestTimeEntry,
+  HarvestUser,
+} from '../types';
 import { format, startOfMonth, endOfMonth } from 'date-fns';
 
 export class HarvestConnector {
@@ -26,7 +34,7 @@ export class HarvestConnector {
     projectId?: string
   ): Promise<HarvestTimeEntry[]> {
     try {
-      const params: any = {
+      const params: Record<string, string | number | undefined> = {
         from: format(fromDate, 'yyyy-MM-dd'),
         to: format(toDate, 'yyyy-MM-dd'),
         per_page: 100,
@@ -58,9 +66,9 @@ export class HarvestConnector {
     }
   }
 
-  async getProjects(isActive = true): Promise<any[]> {
+  async getProjects(isActive = true): Promise<HarvestProject[]> {
     try {
-      const response = await this.client.get('/projects', {
+      const response = await this.client.get<{ projects: HarvestProject[] }>('/projects', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.projects;
@@ -70,9 +78,9 @@ export class HarvestConnector {
     }
   }
 
-  async getClients(isActive = true): Promise<any[]> {
+  async getClients(isActive = true): Promise<HarvestClient[]> {
     try {
-      const response = await this.client.get('/clients', {
+      const response = await this.client.get<{ clients: HarvestClient[] }>('/clients', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.clients;
@@ -82,9 +90,9 @@ export class HarvestConnector {
     }
   }
 
-  async getTasks(): Promise<any[]> {
+  async getTasks(): Promise<HarvestTask[]> {
     try {
-      const response = await this.client.get('/tasks', {
+      const response = await this.client.get<{ tasks: HarvestTask[] }>('/tasks', {
         params: { per_page: 100 },
       });
       return response.data.tasks;
@@ -94,9 +102,9 @@ export class HarvestConnector {
     }
   }
 
-  async getUsers(isActive = true): Promise<any[]> {
+  async getUsers(isActive = true): Promise<HarvestUser[]> {
     try {
-      const response = await this.client.get('/users', {
+      const response = await this.client.get<{ users: HarvestUser[] }>('/users', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.users;
@@ -106,9 +114,9 @@ export class HarvestConnector {
     }
   }
 
-  async getProjectBudget(projectId: string): Promise<any> {
+  async getProjectBudget(projectId: string): Promise<HarvestProjectBudget> {
     try {
-      const response = await this.client.get(`/projects/${projectId}`);
+      const response = await this.client.get<{ project: { budget: number; budget_by: string; budget_is_monthly: boolean } }>(`/projects/${projectId}`);
       return {
         budget: response.data.project.budget,
         budgetBy: response.data.project.budget_by,
@@ -127,7 +135,7 @@ export class HarvestConnector {
     return this.getTimeEntries(fromDate, toDate, clientId);
   }
 
-  private mapTimeEntry(entry: any): HarvestTimeEntry {
+  private mapTimeEntry(entry: HarvestAPITimeEntry): HarvestTimeEntry {
     return {
       entryId: entry.id.toString(),
       date: new Date(entry.spent_date),

--- a/src/services/profitability.service.ts
+++ b/src/services/profitability.service.ts
@@ -53,7 +53,11 @@ export class ProfitabilityService {
     );
 
     const { billable_cost, exclusion_cost, exception_count } =
-      timeEntriesResult.rows[0];
+      timeEntriesResult.rows[0] || {
+        billable_cost: '0',
+        exclusion_cost: '0',
+        exception_count: '0',
+      };
 
     // Get recognised revenue
     const revenueResult = await query<RevenueRow>(
@@ -85,7 +89,8 @@ export class ProfitabilityService {
       [clientId, projectId]
     );
 
-    const { client_name, project_name } = namesResult.rows[0];
+    const { client_name, project_name } =
+      namesResult.rows[0] || { client_name: '', project_name: '' };
 
     const metric: ProfitabilityMetric = {
       month: monthStr,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -168,3 +168,118 @@ export interface AuditLog {
   newValue?: any;
   helpdeskTicketId?: string;
 }
+
+export interface TimeEntryRecord {
+  id: string;
+  person_id: string;
+  client_id: string;
+  project_id: string;
+  task_id: string;
+  billable_rate: number;
+  billable_flag: boolean;
+  cost_rate: number;
+  cost_amount: number;
+  hours: number;
+  date: Date;
+  task_name?: string;
+  task_category?: string;
+  person_name?: string;
+}
+
+export interface RatePolicyRecord {
+  rate: number;
+}
+
+export interface HarvestProject {
+  id: string;
+  name: string;
+  is_active: boolean;
+}
+
+export interface HarvestClient {
+  id: string;
+  name: string;
+  is_active: boolean;
+}
+
+export interface HarvestTask {
+  id: string;
+  name: string;
+  billable_by_default: boolean;
+  is_active: boolean;
+}
+
+export interface HarvestUser {
+  id: string;
+  first_name: string;
+  last_name: string;
+  is_active: boolean;
+}
+
+export interface HarvestProjectBudget {
+  budget: number;
+  budgetBy: string;
+  budgetIsMonthly: boolean;
+}
+
+export interface HarvestAPITimeEntry {
+  id: number;
+  spent_date: string;
+  client?: { name: string };
+  project?: { name: string };
+  task?: { name: string };
+  notes?: string;
+  hours: number;
+  billable: boolean;
+  is_locked: boolean;
+  user?: { first_name: string; last_name: string };
+  user_assignment?: { role: string };
+  billable_rate?: number;
+  cost_rate?: number;
+  external_reference?: { id: string };
+}
+
+export interface HubSpotDeal {
+  id: string;
+  properties: {
+    dealname: string;
+    amount: string;
+    closedate: string;
+    dealstage: string;
+    pipeline: string;
+    hs_arr: string;
+    hs_mrr: string;
+    hs_tcv: string;
+    hs_acv: string;
+  };
+}
+
+export interface HubSpotCompany {
+  id: string;
+  properties: {
+    name: string;
+    domain: string;
+    industry: string;
+    annualrevenue: string;
+    numberofemployees: string;
+    lifecyclestage: string;
+  };
+}
+
+export interface HubSpotAssociation {
+  id: string;
+}
+
+export interface RevenueMetrics {
+  companyName: string;
+  annualRevenue: number;
+  closedRevenue: number;
+  pipelineValue: number;
+  dealCount: number;
+  closedDealCount: number;
+}
+
+export interface SyncResult {
+  success: boolean;
+  recordsProcessed: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,
+    "noImplicitAny": true,
+    "noUncheckedIndexedAccess": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary
- add interfaces for time entries, rate policies, and connector responses
- refactor Harvest and HubSpot connectors to return strongly typed data
- enable stricter compiler checks and fix resulting type issues

## Testing
- `npm run typecheck`
- `npm test`
- `npm run lint` *(fails: react/no-unescaped-entities and other lint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbc0e657c832f9f3416abbb738791