### PR TITLE
Expand TypeScript coverage and add server config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "typecheck": "tsc --noEmit",
-    "build:server": "tsc",
+    "build:server": "tsc -p tsconfig.server.json",
     "migrate": "tsx scripts/migrate.ts",
     "api-dev": "tsx watch src/index.ts",
     "build:api": "tsc -p tsconfig.api.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     ],
     "jsx": "preserve",
     "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -33,6 +32,9 @@
     ]
   },
   "include": [
+    "next-env.d.ts",
+    "app/**/*.{ts,tsx}",
+    "api/**/*.ts",
     "src/**/*.ts"
   ],
   "exclude": [

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist"
+  },
+  "include": [
+    "api/**/*.ts",
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- broaden TypeScript includes for app, api, and src folders
- add dedicated `tsconfig.server.json` and reference in build script
- ensure `next-env.d.ts` remains included at project root

## Testing
- `npm run typecheck`
- `npm test` *(fails: Cannot find module 'supertest'; jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf331550832fa6f283bba1b2e440