### PR TITLE
refactor: streamline ci pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -22,17 +24,7 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run ESLint
@@ -44,22 +36,14 @@ jobs:
       - name: Run unit tests
         run: npm test -- --coverage --passWithNoTests
 
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage/lcov.info
-
-      - name: Cache Next.js build
-        uses: actions/cache@v3
-        with:
-          path: .next/cache
-          key: ${{ runner.os }}-next-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-next-
-
       - name: Build application
         run: npm run build
+
+      - name: SonarQube Scan
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
 
 #  Lighthouse CI Testing (disabled until credentials are configured)
 #  lighthouse:
@@ -96,45 +80,6 @@ jobs:
 #          path: .lighthouseci
 #        if: always()
 
-# SonarQube/SonarCloud Analysis
-  sonarcloud:
-    runs-on: ubuntu-latest
-    needs: ci
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Cache node_modules
-        id: sonar-cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install dependencies
-        if: steps.sonar-cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Download coverage report
-        uses: actions/download-artifact@v3
-        with:
-          name: coverage
-          path: coverage
-
-      - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
 #  Security Audit (Snyk step disabled until credentials are configured)
 #  security:


### PR DESCRIPTION
## Summary
- simplify CI workflow to install, lint, typecheck, test, and build in a single job
- remove caching and coverage artifact steps
- run SonarCloud analysis only when SONAR_TOKEN is available

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, ban-ts-comment, no-html-link-for-pages)*
- `npm run typecheck`
- `npm test -- --passWithNoTests` *(fails: missing supertest, missing jest-environment-jsdom)*
- `npm run build` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf3a51f4832face0eb9db2f9c7fa