### PR TITLE
chore: configure sonarcloud host and coverage check

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,6 +131,13 @@ jobs:
           name: coverage
           path: coverage
 
+      - name: Verify coverage report
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            echo "coverage/lcov.info not found"
+            exit 1
+          fi
+
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v5
         env:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,7 @@ sonar.projectKey=17871787_Account_Manager_Tool
 sonar.organization=17871787
 sonar.projectName=MoA Account Manager AI
 sonar.projectVersion=1.0.0
+sonar.host.url=https://sonarcloud.io
 
 # Source code configuration
 sonar.sources=src,app,api


### PR DESCRIPTION
## Summary
- set `sonar.host.url` to SonarCloud in sonar project configuration
- verify `coverage/lcov.info` exists before Sonar scan

## Testing
- `npm test -- --coverage --passWithNoTests` *(fails: Cannot find module 'supertest'; jest-environment-jsdom missing)*
- `npm ci` *(fails: E403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf3bf1f4832fbbb95a3ee5120953