### PR TITLE
feat: add typed service responses

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -172,3 +172,29 @@ export interface AuditLog {
   newValue?: any;
   helpdeskTicketId?: string;
 }
+
+export interface BudgetVsBurn {
+  budget: number;
+  budgetHours: number;
+  actualHours: number;
+  actualCost: number;
+  monthProgress: number;
+  hoursUtilization: number;
+  costUtilization: number;
+  burnRate: number;
+  forecastToCompletion: number;
+  status: 'over-budget' | 'at-risk' | 'on-track';
+}
+
+export interface MonthlyReportProject {
+  projectName: string;
+  profitability?: ProfitabilityMetric;
+  budgetVsBurn?: BudgetVsBurn | null;
+}
+
+export interface MonthlyReport {
+  clientId: string;
+  month: string;
+  projects: MonthlyReportProject[];
+  generatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- add interfaces for budget vs burn and monthly reports
- return typed responses from export service methods
- use typed generics for database queries

## Testing
- `npm run typecheck`
- `npm test` *(fails: Cannot find module 'supertest'; jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbf339400832f89a5e0c60c667207