### PR TITLE
refactor: tighten query typing

### DIFF
--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -26,7 +26,7 @@ export class HarvestConnector {
     projectId?: string
   ): Promise<HarvestTimeEntry[]> {
     try {
-      const params: any = {
+      const params: Record<string, unknown> = {
         from: format(fromDate, 'yyyy-MM-dd'),
         to: format(toDate, 'yyyy-MM-dd'),
         per_page: 100,
@@ -58,7 +58,7 @@ export class HarvestConnector {
     }
   }
 
-  async getProjects(isActive = true): Promise<any[]> {
+  async getProjects(isActive = true): Promise<unknown[]> {
     try {
       const response = await this.client.get('/projects', {
         params: { is_active: isActive, per_page: 100 },
@@ -70,7 +70,7 @@ export class HarvestConnector {
     }
   }
 
-  async getClients(isActive = true): Promise<any[]> {
+  async getClients(isActive = true): Promise<unknown[]> {
     try {
       const response = await this.client.get('/clients', {
         params: { is_active: isActive, per_page: 100 },
@@ -82,7 +82,7 @@ export class HarvestConnector {
     }
   }
 
-  async getTasks(): Promise<any[]> {
+  async getTasks(): Promise<unknown[]> {
     try {
       const response = await this.client.get('/tasks', {
         params: { per_page: 100 },
@@ -94,7 +94,7 @@ export class HarvestConnector {
     }
   }
 
-  async getUsers(isActive = true): Promise<any[]> {
+  async getUsers(isActive = true): Promise<unknown[]> {
     try {
       const response = await this.client.get('/users', {
         params: { is_active: isActive, per_page: 100 },

--- a/src/models/database.ts
+++ b/src/models/database.ts
@@ -8,12 +8,19 @@ export const pool = new Pool({
   ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });
 
-export async function query<T extends QueryResultRow = any>(
+export async function query<T extends QueryResultRow>(text: string): Promise<QueryResult<T>>;
+export async function query<T extends QueryResultRow>(
   text: string,
-  params?: any[]
+  params: unknown[]
+): Promise<QueryResult<T>>;
+export async function query<T extends QueryResultRow>(
+  text: string,
+  params?: unknown[]
 ): Promise<QueryResult<T>> {
   const start = Date.now();
-  const res = await pool.query<T>(text, params);
+  const res = params
+    ? await pool.query<T>(text, params)
+    : await pool.query<T>(text);
   const duration = Date.now() - start;
   console.log('Executed query', { text, duration, rows: res.rowCount });
   return res;

--- a/src/rules/exception.engine.ts
+++ b/src/rules/exception.engine.ts
@@ -1,4 +1,5 @@
 import { Exception } from '../types';
+import { QueryResultRow } from 'pg';
 import { query } from '../models/database';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -192,7 +193,7 @@ export class ExceptionEngine {
     });
   }
 
-  async detectExceptions(entries: any[]): Promise<Exception[]> {
+  async detectExceptions(entries: QueryResultRow[]): Promise<Exception[]> {
     const exceptions: Exception[] = [];
 
     for (const entry of entries) {
@@ -298,7 +299,7 @@ export class ExceptionEngine {
       JOIN clients c ON te.client_id = c.id
       WHERE e.status = 'pending'`;
 
-    const params: any[] = [];
+    const params: string[] = [];
     if (clientId) {
       queryText += ' AND te.client_id = $1';
       params.push(clientId);
@@ -306,7 +307,7 @@ export class ExceptionEngine {
 
     queryText += ' ORDER BY e.severity DESC, e.created_at DESC';
 
-    const result = await query(queryText, params);
+    const result = await query<Exception>(queryText, params);
     return result.rows;
   }
 

--- a/src/utils/__tests__/sentry.middleware.test.ts
+++ b/src/utils/__tests__/sentry.middleware.test.ts
@@ -2,11 +2,13 @@ import { sentryErrorMiddleware } from '../sentry';
 import type { AppError } from '../../types';
 
 const captureException = jest.fn();
-const withScope = jest.fn((callback: any) => callback({ setContext: jest.fn() }));
+const withScope = jest.fn((callback: unknown) =>
+  (callback as (scope: { setContext: jest.Mock }) => void)({ setContext: jest.fn() })
+);
 
 jest.mock('@sentry/nextjs', () => ({
-  captureException: (...args: any[]) => captureException(...args),
-  withScope: (...args: any[]) => withScope(...args),
+  captureException: (...args: unknown[]) => captureException(...args),
+  withScope: (...args: unknown[]) => withScope(...args),
 }));
 
 describe('sentryErrorMiddleware', () => {


### PR DESCRIPTION
## Summary
- refine `query` function to use typed generics and optional params
- replace `any[]` arrays with explicit types across codebase
- support SQL calls without params via overloads

## Testing
- `npm test` *(fails: Cannot find module 'supertest'; jest-environment-jsdom not found)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bdbf367e18832fa905dbcfaf2cde31