### PR TITLE
ci: add Sonar host URL for scan

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,6 +44,7 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io
 
 #  Lighthouse CI Testing (disabled until credentials are configured)
 #  lighthouse:


### PR DESCRIPTION
## Summary
- include SONAR_HOST_URL for SonarQube scan

## Testing
- `npm test` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc416d804832f80681f2daa79a10d