### PR TITLE
refactor database pool for injection and lazy init

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,4 +1,4 @@
-import { pool } from '../src/models/database';
+import { getPool } from '../src/models/database';
 import fs from 'fs';
 import path from 'path';
 
@@ -13,7 +13,7 @@ async function runMigration() {
     const schema = fs.readFileSync(schemaPath, 'utf8');
 
     // Execute schema
-    await pool.query(schema);
+    await getPool().query(schema);
 
     console.log('✅ Database schema created successfully');
 
@@ -28,7 +28,7 @@ async function runMigration() {
     exitCode = 1;
   } finally {
     try {
-      await pool.end();
+      await getPool().end();
     } catch (closeError) {
       console.error('❌ Failed to close database pool:', closeError);
       exitCode = 1;
@@ -43,7 +43,7 @@ async function seedDatabase() {
   
   try {
     // Insert sample client
-    await pool.query(`
+    await getPool().query(`
       INSERT INTO clients (name, harvest_id, is_active)
       VALUES 
         ('Arla', 'harvest_arla_001', true),
@@ -53,7 +53,7 @@ async function seedDatabase() {
     `);
     
     // Insert sample tasks
-    await pool.query(`
+    await getPool().query(`
       INSERT INTO tasks (name, default_billable, category, is_active)
       VALUES 
         ('Account Management', true, 'billable', true),

--- a/src/api/__tests__/api.test.ts
+++ b/src/api/__tests__/api.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import app from '../../../api/index';
-import { pool } from '../../models/database';
-import { PoolClient } from 'pg';
+import { setPool } from '../../models/database';
+import { Pool, PoolClient } from 'pg';
 
 jest.mock('../../connectors/harvest.connector', () => ({
   HarvestConnector: jest.fn().mockImplementation(() => ({
@@ -30,6 +30,10 @@ const mockClient = {
   release: jest.fn(),
 } as unknown as PoolClient;
 
+const mockPool = {
+  connect: jest.fn(),
+} as unknown as Pool;
+
 describe('API endpoints', () => {
   let connectSpy: jest.SpyInstance;
 
@@ -37,7 +41,8 @@ describe('API endpoints', () => {
     jest.clearAllMocks();
     mockClient.query.mockReset().mockResolvedValue({ rows: [] });
     mockClient.release.mockReset();
-    connectSpy = jest.spyOn(pool, 'connect').mockResolvedValue(mockClient);
+    setPool(mockPool as unknown as Pool);
+    connectSpy = jest.spyOn(mockPool, 'connect').mockResolvedValue(mockClient);
   });
 
   afterEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import routes from './api/routes';
-import { pool } from './models/database';
+import { getPool } from './models/database';
 import { AppError } from './types';
 
 dotenv.config();
@@ -31,7 +31,7 @@ app.use((err: AppError, req: Request, res: Response, next: NextFunction) => {
 async function startServer() {
   try {
     // Test database connection
-    await pool.query('SELECT NOW()');
+    await getPool().query('SELECT NOW()');
     console.log('✅ Database connected successfully');
 
     app.listen(PORT, () => {
@@ -42,7 +42,7 @@ async function startServer() {
   } catch (error) {
     console.error('❌ Failed to start server:', error);
     try {
-      await pool.end();
+      await getPool().end();
     } finally {
       process.exit(1);
     }
@@ -53,7 +53,7 @@ async function startServer() {
 process.on('SIGTERM', async () => {
   console.log('SIGTERM received, closing server...');
   try {
-    await pool.end();
+    await getPool().end();
   } finally {
     process.exit(0);
   }
@@ -62,7 +62,7 @@ process.on('SIGTERM', async () => {
 process.on('SIGINT', async () => {
   console.log('SIGINT received, closing server...');
   try {
-    await pool.end();
+    await getPool().end();
   } finally {
     process.exit(0);
   }

--- a/src/services/__tests__/export.service.test.ts
+++ b/src/services/__tests__/export.service.test.ts
@@ -1,13 +1,13 @@
 import { ExportService } from '../export.service';
 import { InvoiceExport } from '../../types';
-import { pool } from '../../models/database';
+import * as db from '../../models/database';
 
 describe('ExportService', () => {
   const service = new ExportService();
   let querySpy: jest.SpyInstance;
 
   beforeEach(() => {
-    querySpy = jest.spyOn(pool, 'query');
+    querySpy = jest.spyOn(db, 'query');
   });
 
   afterEach(() => {

--- a/src/services/__tests__/profitability.test.ts
+++ b/src/services/__tests__/profitability.test.ts
@@ -1,5 +1,5 @@
 import { ProfitabilityService } from '../profitability.service';
-import { pool } from '../../models/database';
+import * as db from '../../models/database';
 
 describe('ProfitabilityService', () => {
   let service: ProfitabilityService;
@@ -7,7 +7,7 @@ describe('ProfitabilityService', () => {
 
   beforeEach(() => {
     service = new ProfitabilityService();
-    querySpy = jest.spyOn(pool, 'query');
+    querySpy = jest.spyOn(db, 'query');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Lazily initialize PostgreSQL pool via `getPool` and allow tests to inject custom pools
- Update server and migration scripts to use new pool accessor
- Adjust tests to mock queries or supply mock pools

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc4162cc4832fbfc9f59e092cda0a