### PR TITLE
chore: build before lighthouse run

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'next start',
+      startServerCommand: 'npm run build && next start',
       startServerReadyPattern: 'ready on',
       startServerReadyTimeout: 30000,
       url: [


### PR DESCRIPTION
## Summary
- build the app before `next start` for lighthouse runs

## Testing
- `npx lhci autorun` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lhci)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@lhci%2fcli)*
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc870e95c832fa098f70146981682