### PR TITLE
build: include api build and use sonar secret

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,8 +10,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    env:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -27,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build API
+        run: npm run build:api
+
       - name: Run ESLint
         run: npm run lint
 
@@ -40,10 +41,10 @@ jobs:
         run: npm run build
 
       - name: SonarQube Scan
-        if: env.SONAR_TOKEN != ''
+        if: secrets.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v5
         env:
-          SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
 
 #  Lighthouse CI Testing (disabled until credentials are configured)


### PR DESCRIPTION
## Summary
- add API build step before application build
- reference SONAR_TOKEN secret directly when running Sonar scan

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm run build:api` *(fails: Cannot find type definition file for 'jest')*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*
- `npm test -- --coverage --passWithNoTests` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc86f5df0832fb17d99e48c8e5f23