### PR TITLE
Upload coverage and configure Jest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,8 +36,12 @@ jobs:
       - name: Run unit tests
         run: npm test -- --coverage --passWithNoTests
 
-      - name: Build application
-        run: npm run build
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage
 
       - name: SonarQube Scan
         if: env.SONAR_TOKEN != ''
@@ -45,6 +49,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+
+      - name: Build application
+        run: npm run build
 
 #  Lighthouse CI Testing (disabled until credentials are configured)
 #  lighthouse:

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,6 +26,7 @@ const customJestConfig = {
     },
   },
   coverageReporters: ['json', 'lcov', 'text', 'html'],
+  coverageDirectory: 'coverage',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },


### PR DESCRIPTION
## Summary
- ensure Jest writes coverage to `coverage` by explicitly setting `coverageDirectory`
- upload test coverage report as a workflow artifact
- run SonarQube scan after tests so coverage is available

## Testing
- `npm test -- --coverage --passWithNoTests` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc8720238832fab0c5b4646c99a78