### PR TITLE
refactor: add explicit typings for connectors

### DIFF
--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -2,6 +2,44 @@ import axios, { AxiosInstance } from 'axios';
 import { HarvestTimeEntry, HarvestTimeEntryApiResponse } from '../types';
 import { format, startOfMonth, endOfMonth } from 'date-fns';
 
+export interface HarvestProject {
+  id: number;
+  name: string;
+  code?: string | null;
+  is_active: boolean;
+  client?: {
+    id: number;
+    name: string;
+  };
+}
+
+export interface HarvestClient {
+  id: number;
+  name: string;
+  is_active: boolean;
+}
+
+export interface HarvestTask {
+  id: number;
+  name: string;
+  billable_by_default: boolean;
+  is_active: boolean;
+}
+
+export interface HarvestUser {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email?: string;
+  is_active: boolean;
+}
+
+export interface HarvestProjectBudget {
+  budget: number;
+  budgetBy: string;
+  budgetIsMonthly: boolean;
+}
+
 export class HarvestConnector {
   private client: AxiosInstance;
   private accountId: string;
@@ -58,9 +96,9 @@ export class HarvestConnector {
     }
   }
 
-  async getProjects(isActive = true): Promise<unknown[]> {
+  async getProjects(isActive = true): Promise<HarvestProject[]> {
     try {
-      const response = await this.client.get('/projects', {
+      const response = await this.client.get<{ projects: HarvestProject[] }>('/projects', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.projects;
@@ -70,9 +108,9 @@ export class HarvestConnector {
     }
   }
 
-  async getClients(isActive = true): Promise<unknown[]> {
+  async getClients(isActive = true): Promise<HarvestClient[]> {
     try {
-      const response = await this.client.get('/clients', {
+      const response = await this.client.get<{ clients: HarvestClient[] }>('/clients', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.clients;
@@ -82,9 +120,9 @@ export class HarvestConnector {
     }
   }
 
-  async getTasks(): Promise<unknown[]> {
+  async getTasks(): Promise<HarvestTask[]> {
     try {
-      const response = await this.client.get('/tasks', {
+      const response = await this.client.get<{ tasks: HarvestTask[] }>('/tasks', {
         params: { per_page: 100 },
       });
       return response.data.tasks;
@@ -94,9 +132,9 @@ export class HarvestConnector {
     }
   }
 
-  async getUsers(isActive = true): Promise<unknown[]> {
+  async getUsers(isActive = true): Promise<HarvestUser[]> {
     try {
-      const response = await this.client.get('/users', {
+      const response = await this.client.get<{ users: HarvestUser[] }>('/users', {
         params: { is_active: isActive, per_page: 100 },
       });
       return response.data.users;
@@ -106,9 +144,11 @@ export class HarvestConnector {
     }
   }
 
-  async getProjectBudget(projectId: string): Promise<any> {
+  async getProjectBudget(projectId: string): Promise<HarvestProjectBudget> {
     try {
-      const response = await this.client.get(`/projects/${projectId}`);
+      const response = await this.client.get<{
+        project: { budget: number; budget_by: string; budget_is_monthly: boolean };
+      }>(`/projects/${projectId}`);
       return {
         budget: response.data.project.budget,
         budgetBy: response.data.project.budget_by,

--- a/src/connectors/hubspot.connector.ts
+++ b/src/connectors/hubspot.connector.ts
@@ -27,6 +27,20 @@ export interface HubSpotCompany {
   };
 }
 
+export interface HubSpotAssociation {
+  id: string;
+  type?: string;
+}
+
+export interface HubSpotRevenueMetrics {
+  companyName: string;
+  annualRevenue: number;
+  closedRevenue: number;
+  pipelineValue: number;
+  dealCount: number;
+  closedDealCount: number;
+}
+
 export class HubSpotConnector {
   private client: AxiosInstance;
 
@@ -42,12 +56,16 @@ export class HubSpotConnector {
 
   async getDeals(limit = 100): Promise<HubSpotDeal[]> {
     try {
-      const response = await this.client.get('/crm/v3/objects/deals', {
-        params: {
-          limit,
-          properties: 'dealname,amount,closedate,dealstage,pipeline,hs_arr,hs_mrr,hs_tcv,hs_acv',
-        },
-      });
+      const response = await this.client.get<{ results: HubSpotDeal[] }>(
+        '/crm/v3/objects/deals',
+        {
+          params: {
+            limit,
+            properties:
+              'dealname,amount,closedate,dealstage,pipeline,hs_arr,hs_mrr,hs_tcv,hs_acv',
+          },
+        }
+      );
       return response.data.results;
     } catch (error) {
       console.error('Error fetching HubSpot deals:', error);
@@ -57,12 +75,16 @@ export class HubSpotConnector {
 
   async getCompanies(limit = 100): Promise<HubSpotCompany[]> {
     try {
-      const response = await this.client.get('/crm/v3/objects/companies', {
-        params: {
-          limit,
-          properties: 'name,domain,industry,annualrevenue,numberofemployees,lifecyclestage',
-        },
-      });
+      const response = await this.client.get<{ results: HubSpotCompany[] }>(
+        '/crm/v3/objects/companies',
+        {
+          params: {
+            limit,
+            properties:
+              'name,domain,industry,annualrevenue,numberofemployees,lifecyclestage',
+          },
+        }
+      );
       return response.data.results;
     } catch (error) {
       console.error('Error fetching HubSpot companies:', error);
@@ -72,16 +94,21 @@ export class HubSpotConnector {
 
   async getDealsByCompany(companyId: string): Promise<HubSpotDeal[]> {
     try {
-      const response = await this.client.get(`/crm/v3/objects/companies/${companyId}/associations/deals`);
-      const dealIds = response.data.results.map((r: any) => r.id);
-      
+      const response = await this.client.get<{ results: HubSpotAssociation[] }>(
+        `/crm/v3/objects/companies/${companyId}/associations/deals`
+      );
+      const dealIds = response.data.results.map(r => r.id);
+
       if (dealIds.length === 0) return [];
-      
-      const dealsResponse = await this.client.post('/crm/v3/objects/deals/batch/read', {
-        inputs: dealIds.map((id: string) => ({ id })),
-        properties: ['dealname', 'amount', 'closedate', 'dealstage', 'pipeline'],
-      });
-      
+
+      const dealsResponse = await this.client.post<{ results: HubSpotDeal[] }>(
+        '/crm/v3/objects/deals/batch/read',
+        {
+          inputs: dealIds.map((id: string) => ({ id })),
+          properties: ['dealname', 'amount', 'closedate', 'dealstage', 'pipeline'],
+        }
+      );
+
       return dealsResponse.data.results;
     } catch (error) {
       console.error('Error fetching deals by company:', error);
@@ -89,19 +116,22 @@ export class HubSpotConnector {
     }
   }
 
-  async getRevenueMetrics(companyName: string): Promise<any> {
+  async getRevenueMetrics(companyName: string): Promise<HubSpotRevenueMetrics | null> {
     try {
       // Search for company by name
-      const searchResponse = await this.client.post('/crm/v3/objects/companies/search', {
-        filterGroups: [{
-          filters: [{
-            propertyName: 'name',
-            operator: 'EQ',
-            value: companyName,
-          }],
+      const searchResponse = await this.client.post<{ results: HubSpotCompany[] }>(
+        '/crm/v3/objects/companies/search',
+        {
+          filterGroups: [{
+            filters: [{
+              propertyName: 'name',
+              operator: 'EQ',
+              value: companyName,
+            }],
         }],
-        properties: ['name', 'annualrevenue'],
-      });
+          properties: ['name', 'annualrevenue'],
+        }
+      );
 
       if (searchResponse.data.results.length === 0) {
         return null;


### PR DESCRIPTION
## Summary
- add explicit interfaces for Harvest projects, clients, tasks, users, and project budgets
- type HubSpot company associations and revenue metrics

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest' or 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68bdc86b00dc832f9ef34b18fd6bfc56