### PR TITLE
Refine rate policy typing and remove any usages

### DIFF
--- a/src/api/export/routes.ts
+++ b/src/api/export/routes.ts
@@ -38,7 +38,7 @@ router.post('/export/invoice', async (req: Request, res: Response) => {
 
 router.post('/export/csv', async (req: Request, res: Response) => {
   try {
-    const { invoiceExport } = z.object({ invoiceExport: z.any() }).parse(req.body);
+    const { invoiceExport } = z.object({ invoiceExport: z.unknown() }).parse(req.body);
     const csv = await exportService.exportToCSV(invoiceExport);
     res.setHeader('Content-Type', 'text/csv');
     res.setHeader('Content-Disposition', 'attachment; filename="invoice.csv"');

--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -106,7 +106,11 @@ export class HarvestConnector {
     }
   }
 
-  async getProjectBudget(projectId: string): Promise<any> {
+  async getProjectBudget(projectId: string): Promise<{
+    budget: number;
+    budgetBy: string;
+    budgetIsMonthly: boolean;
+  }> {
     try {
       const response = await this.client.get(`/projects/${projectId}`);
       return {

--- a/src/connectors/hubspot.connector.ts
+++ b/src/connectors/hubspot.connector.ts
@@ -73,7 +73,7 @@ export class HubSpotConnector {
   async getDealsByCompany(companyId: string): Promise<HubSpotDeal[]> {
     try {
       const response = await this.client.get(`/crm/v3/objects/companies/${companyId}/associations/deals`);
-      const dealIds = response.data.results.map((r: any) => r.id);
+      const dealIds = response.data.results.map((r: { id: string }) => r.id);
       
       if (dealIds.length === 0) return [];
       
@@ -89,7 +89,14 @@ export class HubSpotConnector {
     }
   }
 
-  async getRevenueMetrics(companyName: string): Promise<any> {
+  async getRevenueMetrics(companyName: string): Promise<{
+    companyName: string;
+    annualRevenue: number;
+    closedRevenue: number;
+    pipelineValue: number;
+    dealCount: number;
+    closedDealCount: number;
+  } | null> {
     try {
       // Search for company by name
       const searchResponse = await this.client.post('/crm/v3/objects/companies/search', {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,10 @@ export interface RatePolicy {
   effectiveTo?: Date;
 }
 
+export interface RatePolicyRow {
+  rate: number;
+}
+
 export interface ProfitabilityMetric {
   month: string;
   client: string;
@@ -105,7 +109,7 @@ export interface Exception {
   reviewedBy?: string;
   reviewedAt?: Date;
   helpdeskTicketId?: string;
-  metadata?: any;
+  metadata?: Record<string, unknown>;
 }
 
 export interface BudgetTracking {
@@ -168,8 +172,8 @@ export interface AuditLog {
   action: string;
   entityType: string;
   entityId: string;
-  oldValue?: any;
-  newValue?: any;
+  oldValue?: unknown;
+  newValue?: unknown;
   helpdeskTicketId?: string;
 }
 

--- a/src/utils/sentry.ts
+++ b/src/utils/sentry.ts
@@ -24,7 +24,7 @@ export const sentryErrorMiddleware = (
 // Helper to capture exceptions with additional context
 export const captureException = (
   error: Error | unknown,
-  context?: Record<string, any>
+  context?: Record<string, unknown>
 ) => {
   Sentry.withScope((scope) => {
     if (context) {
@@ -38,7 +38,7 @@ export const captureException = (
 export const captureMessage = (
   message: string,
   level: Sentry.SeverityLevel = 'info',
-  context?: Record<string, any>
+  context?: Record<string, unknown>
 ) => {
   Sentry.withScope((scope) => {
     if (context) {
@@ -84,7 +84,7 @@ export const setUserContext = (user: {
 export const addBreadcrumb = (
   message: string,
   category: string,
-  data?: Record<string, any>
+  data?: Record<string, unknown>
 ) => {
   Sentry.addBreadcrumb({
     message,


### PR DESCRIPTION
## Summary
- add `RatePolicyRow` interface and type `getApplicableRate`
- generalize `ExceptionRule` metadata and remove remaining `any` casts
- replace miscellaneous `any` usages with explicit types across the codebase

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest', 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc86c0cec832f9e7ef05c32661c91