### PR TITLE
chore: build api before next

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run build:api && next build",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- ensure API TypeScript is built before Next.js build

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'jest'; 403 Forbidden fetching @lhci/cli prevents dependency installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc86d9b10832fb593050b14d8b2c6