### PR TITLE
chore: split jest config into frontend and backend projects

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,9 +2,7 @@ const nextJest = require('next/jest');
 
 const createJestConfig = nextJest({ dir: './' });
 
-/** @type {import('jest').Config} */
-const customJestConfig = {
-  testEnvironment: 'jsdom',
+const sharedConfig = {
   roots: ['<rootDir>/src', '<rootDir>/app'],
   testMatch: [
     '**/__tests__/**/*.+(ts|tsx|js)',
@@ -29,8 +27,28 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
 
-module.exports = createJestConfig(customJestConfig);
+module.exports = async () => {
+  const frontend = await createJestConfig({
+    ...sharedConfig,
+    displayName: 'frontend',
+    testEnvironment: 'jsdom',
+    testPathIgnorePatterns: ['<rootDir>/src/api/', '<rootDir>/src/connectors/'],
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  });
 
+  const backend = await createJestConfig({
+    ...sharedConfig,
+    displayName: 'backend',
+    testEnvironment: 'node',
+    testMatch: [
+      '<rootDir>/src/api/**/__tests__/**/*.+(ts|tsx|js)',
+      '<rootDir>/src/api/**/?(*.)+(spec|test).+(ts|tsx|js)',
+      '<rootDir>/src/connectors/**/__tests__/**/*.+(ts|tsx|js)',
+      '<rootDir>/src/connectors/**/?(*.)+(spec|test).+(ts|tsx|js)',
+    ],
+  });
+
+  return { projects: [frontend, backend] };
+};


### PR DESCRIPTION
## Summary
- configure Jest to run separate frontend (jsdom) and backend (node) test projects
- route API and connector tests through backend project to avoid DOM shims

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc86ffa0c832f881d5bba6b458c66