### PR TITLE
ci: conditionally run sonar scan

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,7 +45,7 @@ jobs:
           path: coverage
 
       - name: SonarQube Scan
-        if: secrets.SONAR_TOKEN != ''
+        if: ${{ secrets.SONAR_TOKEN != '' }}
         uses: SonarSource/sonarqube-scan-action@v5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CI-CD-SETUP.md
+++ b/CI-CD-SETUP.md
@@ -28,7 +28,7 @@ VERCEL_ORG_ID: Your Vercel organization ID
 VERCEL_PROJECT_ID: Your project ID
 
 # Code Quality
-SONAR_TOKEN: SonarCloud token
+SONAR_TOKEN: SonarCloud token (required for SonarQube scan; step is skipped if empty)
 CODECOV_TOKEN: Codecov token (optional)
 SNYK_TOKEN: Snyk security token (optional)
 


### PR DESCRIPTION
## Summary
- skip SonarQube scan when `SONAR_TOKEN` secret is missing
- document required `SONAR_TOKEN` secret for CI/CD setup

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca933b4c832fab42d3e84e9b9e10