### PR TITLE
refactor: split Jest configs

### DIFF
--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -1,0 +1,38 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const config = {
+  roots: ['<rootDir>/src', '<rootDir>/app'],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/types/**',
+    '!**/node_modules/**',
+    '!**/.next/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 10,
+      functions: 10,
+      lines: 10,
+      statements: 10,
+    },
+  },
+  coverageReporters: ['json', 'lcov', 'text', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  displayName: 'backend',
+  testEnvironment: 'node',
+  testMatch: [
+    '<rootDir>/src/api/**/__tests__/**/*.+(ts|tsx|js)',
+    '<rootDir>/src/api/**/?(*.)+(spec|test).+(ts|tsx|js)',
+    '<rootDir>/src/connectors/**/__tests__/**/*.+(ts|tsx|js)',
+    '<rootDir>/src/connectors/**/?(*.)+(spec|test).+(ts|tsx|js)',
+  ],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(config);

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,55 +1,6 @@
-const nextJest = require('next/jest');
-
-const createJestConfig = nextJest({ dir: './' });
-
-const sharedConfig = {
-  roots: ['<rootDir>/src', '<rootDir>/app'],
-  testMatch: [
-    '**/__tests__/**/*.+(ts|tsx|js)',
-    '**/?(*.)+(spec|test).+(ts|tsx|js)',
+module.exports = {
+  projects: [
+    '<rootDir>/jest.frontend.config.js',
+    '<rootDir>/jest.backend.config.js',
   ],
-  collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
-    '!src/**/*.d.ts',
-    '!src/types/**',
-    '!**/node_modules/**',
-    '!**/.next/**',
-  ],
-  coverageThreshold: {
-    global: {
-      branches: 10,
-      functions: 10,
-      lines: 10,
-      statements: 10,
-    },
-  },
-  coverageReporters: ['json', 'lcov', 'text', 'html'],
-  coverageDirectory: 'coverage',
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
-};
-
-module.exports = async () => {
-  const frontend = await createJestConfig({
-    ...sharedConfig,
-    displayName: 'frontend',
-    testEnvironment: 'jsdom',
-    testPathIgnorePatterns: ['<rootDir>/src/api/', '<rootDir>/src/connectors/'],
-    setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  });
-
-  const backend = await createJestConfig({
-    ...sharedConfig,
-    displayName: 'backend',
-    testEnvironment: 'node',
-    testMatch: [
-      '<rootDir>/src/api/**/__tests__/**/*.+(ts|tsx|js)',
-      '<rootDir>/src/api/**/?(*.)+(spec|test).+(ts|tsx|js)',
-      '<rootDir>/src/connectors/**/__tests__/**/*.+(ts|tsx|js)',
-      '<rootDir>/src/connectors/**/?(*.)+(spec|test).+(ts|tsx|js)',
-    ],
-  });
-
-  return { projects: [frontend, backend] };
 };

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -1,0 +1,37 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const config = {
+  roots: ['<rootDir>/src', '<rootDir>/app'],
+  testMatch: [
+    '**/__tests__/**/*.+(ts|tsx|js)',
+    '**/?(*.)+(spec|test).+(ts|tsx|js)',
+  ],
+  collectCoverageFrom: [
+    'src/**/*.{ts,tsx}',
+    '!src/**/*.d.ts',
+    '!src/types/**',
+    '!**/node_modules/**',
+    '!**/.next/**',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 10,
+      functions: 10,
+      lines: 10,
+      statements: 10,
+    },
+  },
+  coverageReporters: ['json', 'lcov', 'text', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  displayName: 'frontend',
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['<rootDir>/src/api/', '<rootDir>/src/connectors/'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+};
+
+module.exports = createJestConfig(config);


### PR DESCRIPTION
## Summary
- split Next.js Jest config into frontend and backend static configs
- reference both configs via a top-level `projects` entry

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden retrieving @lhci/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68bdca8f0e74832fb609423b87153fef