### PR TITLE
chore: streamline build pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build API
-        run: npm run build:api
-
       - name: Run ESLint
         run: npm run lint
 
@@ -50,6 +47,9 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
+
+      - name: Build API
+        run: npm run build:api
 
       - name: Build application
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "next dev",
-    "build": "npm run build:api && next build",
+    "build": "next build",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- build API separately and run `next build` in the main build step
- ensure API compilation happens once before deployment

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@lhci%2fcli)*
- `npm test --silent` *(fails: jest: not found)*
- `npm run lint --silent` *(fails: next: not found)*
- `npm run typecheck --silent` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68bdca8f8fe4832f9304b23fef211c41