### PR TITLE
ci: cache npm deps and archive API build

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -49,7 +50,13 @@ jobs:
           SONAR_HOST_URL: https://sonarcloud.io
 
       - name: Build API
-        run: npm run build:api
+        run: npm run build:api # compiles Express API to dist for deployment
+
+      - name: Upload API build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: api-dist
+          path: dist
 
       - name: Build application
         run: npm run build


### PR DESCRIPTION
## Summary
- enable npm caching for node setup in CI job
- build and upload express API artifact

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@lhci%2fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68bdce645230832f9c71e01234082e3a