### PR TITLE
Handle zero expected margin in backTestAccuracy

### DIFF
--- a/src/services/__tests__/profitability.test.ts
+++ b/src/services/__tests__/profitability.test.ts
@@ -109,5 +109,28 @@ describe('ProfitabilityService', () => {
       expect(result.variance).toBeLessThanOrEqual(1);
       expect(result.withinTolerance).toBe(true);
     });
+
+    it('should return infinite variance when expected margin is 0', async () => {
+      querySpy.mockImplementation(() => Promise.resolve({
+        rows: [{
+          billable_cost: '0',
+          exclusion_cost: '0',
+          exception_count: '0',
+          recognised_revenue: 100000,
+          client_name: 'Test Client',
+          project_name: 'Test Project'
+        }]
+      }));
+
+      const result = await service.backTestAccuracy(
+        'client-id',
+        'project-id',
+        new Date('2024-01-01'),
+        0
+      );
+
+      expect(result.variance).toBe(Infinity);
+      expect(result.withinTolerance).toBe(false);
+    });
   });
 });

--- a/src/services/profitability.service.ts
+++ b/src/services/profitability.service.ts
@@ -197,6 +197,10 @@ export class ProfitabilityService {
     }));
   }
 
+  /**
+   * Compare expected margin with calculated margin.
+   * Variance is set to Infinity if expectedMargin is 0 to avoid division by zero.
+   */
   async backTestAccuracy(
     clientId: string,
     projectId: string,
@@ -205,7 +209,11 @@ export class ProfitabilityService {
   ): Promise<{ variance: number; withinTolerance: boolean; calculatedMargin: number }> {
     // Calculate WITHOUT persisting (read-only for back-testing)
     const calculated = await this.calculateProfitabilityReadOnly(clientId, projectId, month);
-    const variance = Math.abs(calculated.margin - expectedMargin) / expectedMargin * 100;
+    // Avoid division by zero when the expected margin is 0
+    const variance =
+      expectedMargin === 0
+        ? Infinity
+        : (Math.abs(calculated.margin - expectedMargin) / Math.abs(expectedMargin)) * 100;
     const withinTolerance = variance <= 1; // ±1% tolerance
 
     return {


### PR DESCRIPTION
## Summary
- guard against division by zero in `ProfitabilityService.backTestAccuracy`
- document infinity variance behavior and add unit test for zero expected margin

## Testing
- `npm install` (failed: 403 Forbidden)
- `npm test` (failed: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68bdd0776248832f93a1332b9709a7ab