### PR TITLE
chore: run CI on develop pull requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- allow pull request CI to run against the develop branch

## Testing
- `npm test -- --passWithNoTests` *(fails: jest not found)*
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2f80d14832fb28b29b0e92f0fa9