### PR TITLE
chore: configure npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+@lhci:registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Add .npmrc to force public npm registry for LHCI packages

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@lhci%2fcli)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2fb3afc832faf5153196926025d