### PR TITLE
chore: add dummy env vars for ci

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,13 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      HARVEST_ACCESS_TOKEN: dummy_harvest_access_token
+      HARVEST_ACCOUNT_ID: dummy_harvest_account_id
+      HUBSPOT_API_KEY: dummy_hubspot_api_key
+      MS_TENANT_ID: dummy_ms_tenant_id
+      MS_CLIENT_ID: dummy_ms_client_id
+      MS_CLIENT_SECRET: dummy_ms_client_secret
 
     steps:
       - name: Checkout code
@@ -64,6 +71,13 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     needs: ci
+    env:
+      HARVEST_ACCESS_TOKEN: dummy_harvest_access_token
+      HARVEST_ACCOUNT_ID: dummy_harvest_account_id
+      HUBSPOT_API_KEY: dummy_hubspot_api_key
+      MS_TENANT_ID: dummy_ms_tenant_id
+      MS_CLIENT_ID: dummy_ms_client_id
+      MS_CLIENT_SECRET: dummy_ms_client_secret
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- add dummy env vars to ci job
- add dummy env vars to lighthouse job

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@lhci%2fcli)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8897644832f894e9ed47b7ec52a