### PR TITLE
Handle missing profitability names row

### DIFF
--- a/src/services/__tests__/profitability.test.ts
+++ b/src/services/__tests__/profitability.test.ts
@@ -84,6 +84,39 @@ describe('ProfitabilityService', () => {
       expect(result.marginPercentage).toBe(0);
       expect(result.margin).toBe(-15000);
     });
+
+    it('should throw when client or project names are missing', async () => {
+      querySpy.mockImplementation((sql: string) => {
+        if (sql.includes('time_entries')) {
+          return Promise.resolve({
+            rows: [{
+              billable_cost: '10000',
+              exclusion_cost: '2000',
+              exception_count: '1'
+            }]
+          });
+        }
+
+        if (sql.includes('sft_revenue')) {
+          return Promise.resolve({
+            rows: [{ recognised_revenue: '15000' }]
+          });
+        }
+
+        if (sql.includes('clients')) {
+          return Promise.resolve({ rows: [] });
+        }
+
+        return Promise.resolve({ rows: [] });
+      });
+
+      await expect(
+        service.calculateProfitability('client-id', 'project-id', new Date('2024-01-01'))
+      ).rejects.toMatchObject({
+        message: 'Client or project not found',
+        status: 404
+      });
+    });
   });
 
   describe('backTestAccuracy', () => {

--- a/src/services/profitability.service.ts
+++ b/src/services/profitability.service.ts
@@ -1,4 +1,4 @@
-import { ProfitabilityMetric } from '../types';
+import { AppError, ProfitabilityMetric } from '../types';
 import { query } from '../models/database';
 import { format } from 'date-fns';
 
@@ -85,7 +85,15 @@ export class ProfitabilityService {
       [clientId, projectId]
     );
 
-    const { client_name, project_name } = namesResult.rows[0];
+    const nameRow = namesResult.rows[0];
+
+    if (!nameRow) {
+      const error = new Error('Client or project not found') as AppError;
+      error.status = 404;
+      throw error;
+    }
+
+    const { client_name, project_name } = nameRow;
 
     const metric: ProfitabilityMetric = {
       month: monthStr,


### PR DESCRIPTION
## Summary
- throw an AppError when profitability name lookup returns no rows so callers can respond with a 404
- cover the missing-name scenario with a new negative-path profitability service test

## Testing
- NEXT_PRIVATE_SKIP_LOAD_PATCH=1 npx jest src/services/__tests__/profitability.test.ts --config jest.backend.config.js *(fails: Next.js lockfile patch attempts to fetch swc deps without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa84960b8832f8eeb65d6d4714509