### PR TITLE
Fix profitability trend interval and add tests

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,16 @@
 // Jest setup file for additional configurations
 require('@testing-library/jest-dom');
 
+const { TextEncoder, TextDecoder } = require('util');
+
+if (!global.TextEncoder) {
+  global.TextEncoder = TextEncoder;
+}
+
+if (!global.TextDecoder) {
+  global.TextDecoder = TextDecoder;
+}
+
 global.console = {
   ...console,
   error: jest.fn(),

--- a/src/services/__tests__/profitability.test.ts
+++ b/src/services/__tests__/profitability.test.ts
@@ -1,22 +1,21 @@
+jest.mock('../../models/database', () => ({
+  query: jest.fn()
+}));
+
 import { ProfitabilityService } from '../profitability.service';
 import * as db from '../../models/database';
 
 describe('ProfitabilityService', () => {
   let service: ProfitabilityService;
-  let querySpy: jest.SpyInstance;
+  const queryMock = db.query as jest.MockedFunction<typeof db.query>;
 
   beforeEach(() => {
     service = new ProfitabilityService();
-    querySpy = jest.spyOn(db, 'query');
-  });
-
-  afterEach(() => {
-    querySpy.mockRestore();
   });
 
   describe('calculateProfitability', () => {
     it('should calculate profitability correctly', async () => {
-      querySpy.mockImplementation((sql: string) => {
+      queryMock.mockImplementation((sql: string) => {
         if (sql.includes('time_entries')) {
           return Promise.resolve({
             rows: [{
@@ -64,7 +63,7 @@ describe('ProfitabilityService', () => {
     });
 
     it('should handle zero revenue gracefully', async () => {
-      querySpy.mockImplementation(() => Promise.resolve({
+      queryMock.mockImplementation(() => Promise.resolve({
         rows: [{
           billable_cost: '10000',
           exclusion_cost: '5000',
@@ -86,9 +85,49 @@ describe('ProfitabilityService', () => {
     });
   });
 
+  describe('getClientProfitabilityTrend', () => {
+    it('should query profitability metrics within the requested interval', async () => {
+      const mockRows = [
+        {
+          month: new Date('2024-03-01'),
+          client_name: 'Client A',
+          project_name: 'Project A',
+          billable_cost: '1000',
+          exclusion_cost: '100',
+          recognised_revenue: '2000',
+          margin: '900',
+          margin_percentage: '45',
+          exceptions_count: 1
+        }
+      ];
+
+      queryMock.mockResolvedValue({ rows: mockRows });
+
+      const result = await service.getClientProfitabilityTrend('client-id', 3);
+
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      const [sql, params] = queryMock.mock.calls[0];
+      expect(sql).toContain('$2::interval');
+      expect(params).toEqual(['client-id', '3 months']);
+      expect(result).toEqual([
+        {
+          month: '2024-03',
+          client: 'Client A',
+          project: 'Project A',
+          billableCost: 1000,
+          exclusionCost: 100,
+          recognisedRevenue: 2000,
+          margin: 900,
+          marginPercentage: 45,
+          exceptionsCount: 1
+        }
+      ]);
+    });
+  });
+
   describe('backTestAccuracy', () => {
     it('should validate margin within tolerance', async () => {
-      querySpy.mockImplementation(() => Promise.resolve({
+      queryMock.mockImplementation(() => Promise.resolve({
         rows: [{
           billable_cost: '60000',
           exclusion_cost: '0',
@@ -111,7 +150,7 @@ describe('ProfitabilityService', () => {
     });
 
     it('should return infinite variance when expected margin is 0', async () => {
-      querySpy.mockImplementation(() => Promise.resolve({
+      queryMock.mockImplementation(() => Promise.resolve({
         rows: [{
           billable_cost: '0',
           exclusion_cost: '0',

--- a/src/services/profitability.service.ts
+++ b/src/services/profitability.service.ts
@@ -179,7 +179,7 @@ export class ProfitabilityService {
       JOIN clients c ON pm.client_id = c.id
       JOIN projects p ON pm.project_id = p.id
       WHERE pm.client_id = $1
-        AND pm.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL $2)
+        AND pm.month >= DATE_TRUNC('month', CURRENT_DATE - ($2::interval))
       ORDER BY pm.month DESC`,
       [clientId, `${months} months`]
     );


### PR DESCRIPTION
## Summary
- ensure profitability trend query casts the interval parameter to avoid syntax issues
- polyfill TextEncoder/TextDecoder in Jest setup for pg compatibility during tests
- mock the database layer in profitability service tests and add coverage for getClientProfitabilityTrend

## Testing
- npm test -- --runTestsByPath src/services/__tests__/profitability.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cfa8422170832fa1c86861969bf4bb