### PR TITLE
Refactor HubSpot upload storage to tmp and add tests

### DIFF
--- a/app/api/hubspot/upload/__tests__/route.test.ts
+++ b/app/api/hubspot/upload/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import type { NextRequest } from 'next/server';
+
+describe('HubSpot upload route', () => {
+  const storageDir = path.join(
+    os.tmpdir(),
+    `hubspot-upload-test-${Date.now().toString(36)}`
+  );
+  let POST: typeof import('../route').POST;
+  let GET: typeof import('../route').GET;
+  let DELETE: typeof import('../route').DELETE;
+
+  beforeAll(async () => {
+    process.env.HUBSPOT_DEALS_STORAGE_DIR = storageDir;
+    const routeModule = await import('../route');
+    POST = routeModule.POST;
+    GET = routeModule.GET;
+    DELETE = routeModule.DELETE;
+  });
+
+  afterAll(async () => {
+    await fs.rm(storageDir, { recursive: true, force: true });
+    delete process.env.HUBSPOT_DEALS_STORAGE_DIR;
+  });
+
+  it('stores uploaded deals in the temporary storage directory', async () => {
+    const csvContent = 'Deal ID,Deal Name,Amount\n1,Test Deal,123.45\n';
+    const blob = new Blob([csvContent], { type: 'text/csv' });
+    const file = new File([blob], 'deals.csv', { type: 'text/csv' });
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const request = new Request('http://localhost/api/hubspot/upload', {
+      method: 'POST',
+      body: formData,
+      // @ts-expect-error Duplex is required by the Node.js fetch implementation
+      duplex: 'half',
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.dealsCount).toBe(1);
+
+    const getResponse = await GET(
+      new Request('http://localhost/api/hubspot/upload') as unknown as NextRequest
+    );
+    const getPayload = await getResponse.json();
+
+    expect(getResponse.status).toBe(200);
+    expect(getPayload.count).toBe(1);
+    expect(getPayload.deals[0].name).toBe('Test Deal');
+
+    const deleteResponse = await DELETE(
+      new Request('http://localhost/api/hubspot/upload', { method: 'DELETE' }) as unknown as NextRequest
+    );
+    const deletePayload = await deleteResponse.json();
+
+    expect(deleteResponse.status).toBe(200);
+    expect(deletePayload.success).toBe(true);
+
+    const finalGet = await GET(
+      new Request('http://localhost/api/hubspot/upload') as unknown as NextRequest
+    );
+    const finalPayload = await finalGet.json();
+
+    expect(finalPayload.count).toBe(0);
+  });
+});

--- a/app/api/hubspot/upload/storage.ts
+++ b/app/api/hubspot/upload/storage.ts
@@ -1,0 +1,68 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+export interface Deal {
+  id?: string;
+  name: string;
+  stage?: string;
+  amount?: number;
+  closeDate?: string;
+  owner?: string;
+  company?: string;
+  status?: string;
+  [key: string]: unknown;
+}
+
+const STORAGE_ENV_KEY = 'HUBSPOT_DEALS_STORAGE_DIR';
+const STORAGE_FILENAME = 'imported_deals.json';
+
+function getStorageDirectory() {
+  const baseDir =
+    process.env[STORAGE_ENV_KEY] ?? path.join(os.tmpdir(), 'hubspot-deals');
+  return baseDir;
+}
+
+function getStorageFilePath() {
+  return path.join(getStorageDirectory(), STORAGE_FILENAME);
+}
+
+async function ensureStorageDirectory() {
+  await fs.mkdir(getStorageDirectory(), { recursive: true });
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === 'object' && 'code' in error);
+}
+
+export async function loadStoredDeals(): Promise<Deal[]> {
+  try {
+    const data = await fs.readFile(getStorageFilePath(), 'utf-8');
+    return JSON.parse(data) as Deal[];
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function storeDeals(deals: Deal[]): Promise<void> {
+  await ensureStorageDirectory();
+  await fs.writeFile(
+    getStorageFilePath(),
+    JSON.stringify(deals, null, 2),
+    'utf-8'
+  );
+}
+
+export async function clearStoredDeals(): Promise<void> {
+  try {
+    await fs.unlink(getStorageFilePath());
+  } catch (error: unknown) {
+    if (isNodeError(error) && error.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+}

--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -31,6 +31,8 @@ const config = {
     '<rootDir>/src/api/**/?(*.)+(spec|test).+(ts|tsx|js)',
     '<rootDir>/src/connectors/**/__tests__/**/*.+(ts|tsx|js)',
     '<rootDir>/src/connectors/**/?(*.)+(spec|test).+(ts|tsx|js)',
+    '<rootDir>/app/api/**/__tests__/**/*.+(ts|tsx|js)',
+    '<rootDir>/app/api/**/?(*.)+(spec|test).+(ts|tsx|js)',
   ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -30,7 +30,11 @@ const config = {
   },
   displayName: 'frontend',
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: ['<rootDir>/src/api/', '<rootDir>/src/connectors/'],
+  testPathIgnorePatterns: [
+    '<rootDir>/src/api/',
+    '<rootDir>/src/connectors/',
+    '<rootDir>/app/api/',
+  ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 };
 


### PR DESCRIPTION
## Summary
- replace direct filesystem writes in the HubSpot upload API with a tmp-based storage helper compatible with production deployments
- update GET/DELETE handlers to use the new storage helper and improve data parsing helpers
- add backend Jest coverage for the HubSpot upload route and configure Jest projects to pick it up

## Testing
- npm test -- --runTestsByPath app/api/hubspot/upload/__tests__/route.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68cfa8428024832f8dbc74e6616418a1