### PR TITLE
Fix lint failures caused by console logging

### DIFF
--- a/app/components/HubSpotDashboardEnhanced.tsx
+++ b/app/components/HubSpotDashboardEnhanced.tsx
@@ -103,7 +103,7 @@ export function HubSpotDashboardEnhanced() {
       const response = await fetch("/api/hubspot/deals?limit=50");
       if (!response.ok) {
         // If API fails, try to get uploaded deals
-        console.log("HubSpot API failed, checking for uploaded deals...");
+        console.warn("HubSpot API failed, checking for uploaded deals...");
         const uploadResponse = await fetch("/api/hubspot/upload");
         if (uploadResponse.ok) {
           const uploadData = await uploadResponse.json();

--- a/app/components/TimeEntriesTable.tsx
+++ b/app/components/TimeEntriesTable.tsx
@@ -40,8 +40,6 @@ export function TimeEntriesTable() {
   const [error, setError] = useState<string | null>(null);
 
   const fetchTimeEntries = async () => {
-    console.log('Fetching time entries with:', { from, to, page });
-    
     if (!from || !to) {
       setError("Please select both from and to dates");
       return;
@@ -52,12 +50,9 @@ export function TimeEntriesTable() {
 
     try {
       const url = `/api/harvest/time-entries?from=${from}&to=${to}&page=${page}`;
-      console.log('Fetching from:', url);
-      
+
       const response = await fetch(url, { cache: "no-store" });
 
-      console.log('Response status:', response.status);
-      
       if (!response.ok) {
         const errorText = await response.text();
         console.error('Error response:', errorText);
@@ -65,7 +60,6 @@ export function TimeEntriesTable() {
       }
 
       const result = await response.json();
-      console.log('Received data:', result);
       setData(result);
     } catch (err) {
       console.error('Fetch error:', err);

--- a/app/components/TimeEntriesTableEnhanced.tsx
+++ b/app/components/TimeEntriesTableEnhanced.tsx
@@ -43,8 +43,6 @@ export function TimeEntriesTableEnhanced() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
   const fetchTimeEntries = async () => {
-    console.log('Fetching time entries with:', { from, to, page });
-
     if (!from || !to) {
       setError("Please select both from and to dates");
       return;
@@ -55,11 +53,8 @@ export function TimeEntriesTableEnhanced() {
 
     try {
       const url = `/api/harvest/time-entries?from=${from}&to=${to}&page=${page}`;
-      console.log('Fetching from:', url);
 
       const response = await fetch(url, { cache: "no-store" });
-
-      console.log('Response status:', response.status);
 
       if (!response.ok) {
         const errorText = await response.text();
@@ -68,7 +63,6 @@ export function TimeEntriesTableEnhanced() {
       }
 
       const result = await response.json();
-      console.log('Received data:', result);
       setData(result);
       setLastRefresh(new Date());
     } catch (err) {

--- a/app/hubspot/connect/page.tsx
+++ b/app/hubspot/connect/page.tsx
@@ -44,7 +44,7 @@ export default function HubSpotConnectPage() {
             </button>
 
             <div className="text-sm text-gray-500">
-              By connecting, you'll grant this app access to:
+              By connecting, you&apos;ll grant this app access to:
               <ul className="mt-2 text-left space-y-1">
                 <li>• Read and write contacts</li>
                 <li>• Read and write companies</li>

--- a/app/hubspot/upload/page.tsx
+++ b/app/hubspot/upload/page.tsx
@@ -28,7 +28,7 @@ export default function HubSpotUploadPage() {
             <li>Log into your HubSpot account</li>
             <li>Navigate to Sales → Deals</li>
             <li>Select the deals you want to export (or select all)</li>
-            <li>Click the "Export" button in the top toolbar</li>
+            <li>Click the &quot;Export&quot; button in the top toolbar</li>
             <li>Choose Excel or CSV format</li>
             <li>Download the file and upload it here</li>
           </ol>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import dotenv from 'dotenv';
 import app from './app';
 import { getPool } from './models/database';
+import { logger } from './utils/logger';
 
 dotenv.config();
 
@@ -10,15 +11,15 @@ async function startServer() {
   try {
     // Test database connection
     await getPool().query('SELECT NOW()');
-    console.log('✅ Database connected successfully');
+    logger.info('✅ Database connected successfully');
 
     app.listen(PORT, () => {
-      console.log(`🚀 MoA Account Manager AI server running on port ${PORT}`);
-      console.log(`📊 Dashboard will be available at http://localhost:${PORT}`);
-      console.log(`🔌 API endpoints available at http://localhost:${PORT}/api`);
+      logger.info(`🚀 MoA Account Manager AI server running on port ${PORT}`);
+      logger.info(`📊 Dashboard will be available at http://localhost:${PORT}`);
+      logger.info(`🔌 API endpoints available at http://localhost:${PORT}/api`);
     });
   } catch (error) {
-    console.error('❌ Failed to start server:', error);
+    logger.error('❌ Failed to start server:', error);
     try {
       await getPool().end();
     } finally {
@@ -29,7 +30,7 @@ async function startServer() {
 
 // Graceful shutdown
 process.on('SIGTERM', async () => {
-  console.log('SIGTERM received, closing server...');
+  logger.info('SIGTERM received, closing server...');
   try {
     await getPool().end();
   } finally {
@@ -38,7 +39,7 @@ process.on('SIGTERM', async () => {
 });
 
 process.on('SIGINT', async () => {
-  console.log('SIGINT received, closing server...');
+  logger.info('SIGINT received, closing server...');
   try {
     await getPool().end();
   } finally {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -13,9 +13,11 @@ try {
   });
 } catch {
   logger = {
+    // eslint-disable-next-line no-console
     info: console.log,
     error: console.error,
     warn: console.warn,
+    // eslint-disable-next-line no-console
     debug: console.debug,
   };
 }


### PR DESCRIPTION
## Summary
- remove debug `console.log` calls from the Harvest time entry components to satisfy the lint `no-console` rule
- swap the HubSpot deals fallback message to `console.warn` and escape UI copy flagged by `react/no-unescaped-entities`
- route server bootstrap messages through the shared logger and annotate its console fallback so linting can pass

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfab7297a0832faf65d8c8d7db7ce0