### PR TITLE
Refactor HubSpot storage to PostgreSQL and stabilize build

### DIFF
--- a/app/api/hubspot/upload/__tests__/storage.test.ts
+++ b/app/api/hubspot/upload/__tests__/storage.test.ts
@@ -1,0 +1,143 @@
+import { setPool } from '../../../../../src/models/database';
+import {
+  clearStoredDeals,
+  loadStoredDeals,
+  storeDeals,
+  Deal,
+} from '../storage';
+
+interface StoredDeal {
+  dealId: string;
+  payload: Deal;
+  sortOrder: number;
+}
+
+class InMemoryDealStore {
+  private deals = new Map<string, StoredDeal>();
+  private snapshot: Map<string, StoredDeal> | null = null;
+
+  async handleQuery(text: string, params: unknown[] = []) {
+    const normalized = text.trim();
+
+    if (normalized === 'BEGIN') {
+      this.snapshot = new Map(this.deals);
+      return { rows: [] };
+    }
+
+    if (normalized === 'COMMIT') {
+      this.snapshot = null;
+      return { rows: [] };
+    }
+
+    if (normalized === 'ROLLBACK') {
+      if (this.snapshot) {
+        this.deals = new Map(this.snapshot);
+      }
+      this.snapshot = null;
+      return { rows: [] };
+    }
+
+    if (normalized.startsWith('CREATE TABLE')) {
+      return { rows: [] };
+    }
+
+    if (normalized.startsWith('CREATE INDEX')) {
+      return { rows: [] };
+    }
+
+    if (normalized.startsWith('DELETE FROM hubspot_deal_imports')) {
+      this.deals.clear();
+      return { rows: [] };
+    }
+
+    if (normalized.startsWith('INSERT INTO hubspot_deal_imports')) {
+      for (let index = 0; index < params.length; index += 3) {
+        const dealId = params[index] as string;
+        const rawPayload = params[index + 1] as string;
+        const sortOrder = params[index + 2] as number;
+        const payload = JSON.parse(rawPayload) as Deal;
+        this.deals.set(dealId, {
+          dealId,
+          payload,
+          sortOrder,
+        });
+      }
+      return { rows: [] };
+    }
+
+    if (normalized.startsWith('SELECT data FROM hubspot_deal_imports')) {
+      const rows = Array.from(this.deals.values())
+        .sort((a, b) => a.sortOrder - b.sortOrder)
+        .map((item) => ({ data: item.payload }));
+      return { rows };
+    }
+
+    throw new Error(`Unsupported query: ${normalized}`);
+  }
+}
+
+class MockClient {
+  constructor(private readonly store: InMemoryDealStore) {}
+
+  query(text: string, params?: unknown[]) {
+    return this.store.handleQuery(text, params);
+  }
+
+  release() {
+    return undefined;
+  }
+}
+
+class MockPool {
+  constructor(private readonly store: InMemoryDealStore) {}
+
+  connect() {
+    return Promise.resolve(new MockClient(this.store));
+  }
+
+  query(text: string, params?: unknown[]) {
+    return this.store.handleQuery(text, params);
+  }
+}
+
+describe('HubSpot durable deal storage', () => {
+  beforeEach(() => {
+    const store = new InMemoryDealStore();
+    const pool = new MockPool(store);
+    setPool(pool as unknown as any);
+  });
+
+  it('persists deals and returns them in insertion order', async () => {
+    const deals: Deal[] = [
+      { id: 'deal-1', name: 'First', amount: 100 },
+      { id: 'deal-2', name: 'Second', amount: 200 },
+    ];
+
+    await storeDeals(deals);
+
+    const stored = await loadStoredDeals();
+    expect(stored).toHaveLength(2);
+    expect(stored[0]).toMatchObject({ id: 'deal-1', name: 'First', amount: 100 });
+    expect(stored[1]).toMatchObject({ id: 'deal-2', name: 'Second', amount: 200 });
+  });
+
+  it('replaces existing snapshot when new deals are stored', async () => {
+    await storeDeals([{ id: 'old', name: 'Old Deal' }]);
+
+    await storeDeals([{ id: 'new', name: 'New Deal', amount: 50 }]);
+
+    const stored = await loadStoredDeals();
+    expect(stored).toEqual([
+      expect.objectContaining({ id: 'new', name: 'New Deal', amount: 50 }),
+    ]);
+  });
+
+  it('clears all deals when requested', async () => {
+    await storeDeals([{ id: 'temp', name: 'Temp Deal' }]);
+
+    await clearStoredDeals();
+
+    const stored = await loadStoredDeals();
+    expect(stored).toHaveLength(0);
+  });
+});

--- a/app/api/hubspot/upload/route.ts
+++ b/app/api/hubspot/upload/route.ts
@@ -8,6 +8,8 @@ import {
   storeDeals,
 } from './storage';
 
+export const runtime = 'nodejs';
+
 type RawDealRow = Record<string, unknown>;
 
 function getFirstString(

--- a/docs/api.md
+++ b/docs/api.md
@@ -144,6 +144,20 @@ Sync monthly revenue from Sales Forecast Tracker.
 }
 ```
 
+## HubSpot Deals Upload Storage
+
+The `/app/api/hubspot/upload` routes persist uploaded deal files to the
+`hubspot_deal_imports` table in PostgreSQL. Each record stores the parsed deal
+payload as JSON (`data` column) along with a deterministic `sort_order` so the
+API can return the deals in the same order they were imported.
+
+- Storage is transactional: existing rows are removed and the new snapshot is
+  inserted inside a single transaction to avoid partially written uploads.
+- Re-importing the same deal updates the existing row and refreshes the
+  `updated_at` timestamp.
+- Clearing the cache (`DELETE /app/api/hubspot/upload`) simply truncates the
+  table, ensuring durability across deployments and server restarts.
+
 ## Exceptions
 
 ### `GET /api/exceptions/pending`

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+if (typeof process.env.NEXT_PRIVATE_SKIP_LOCKFILE_PATCH === 'undefined') {
+  process.env.NEXT_PRIVATE_SKIP_LOCKFILE_PATCH = '1';
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/run-next-build.js",
     "start": "next start",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/run-next-build.js
+++ b/scripts/run-next-build.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process');
+
+const env = { ...process.env };
+
+if (!env.NEXT_PRIVATE_SKIP_LOCKFILE_PATCH) {
+  env.NEXT_PRIVATE_SKIP_LOCKFILE_PATCH = '1';
+}
+
+if (!env.NEXT_IGNORE_INCORRECT_LOCKFILE) {
+  env.NEXT_IGNORE_INCORRECT_LOCKFILE = '1';
+}
+
+const result = spawnSync('next', ['build'], {
+  stdio: 'inherit',
+  env,
+});
+
+if (result.error) {
+  throw result.error;
+}
+
+process.exit(result.status ?? 0);

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -186,6 +186,18 @@ CREATE TABLE IF NOT EXISTS invoice_exports (
     generated_by UUID REFERENCES users(id)
 );
 
+-- HubSpot imported deals storage for durable uploads
+CREATE TABLE IF NOT EXISTS hubspot_deal_imports (
+    deal_id TEXT PRIMARY KEY,
+    data JSONB NOT NULL,
+    sort_order INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hubspot_deal_imports_sort_order
+    ON hubspot_deal_imports (sort_order);
+
 -- Create indexes for performance
 CREATE INDEX idx_time_entries_date ON time_entries(date);
 CREATE INDEX idx_time_entries_client_project ON time_entries(client_id, project_id);
@@ -212,4 +224,6 @@ CREATE TRIGGER update_tasks_updated_at BEFORE UPDATE ON tasks
 CREATE TRIGGER update_people_updated_at BEFORE UPDATE ON people
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_exceptions_updated_at BEFORE UPDATE ON exceptions
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_hubspot_deal_imports_updated_at BEFORE UPDATE ON hubspot_deal_imports
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/src/api/sync/batchInsert.ts
+++ b/src/api/sync/batchInsert.ts
@@ -38,4 +38,4 @@ export async function batchInsert(
   }
 }
 
-export { RecordRow };
+export type { RecordRow };


### PR DESCRIPTION
## Summary
- replace the HubSpot upload storage module with a PostgreSQL-backed implementation and force the route onto the Node runtime
- add schema migration entries, docs, and integration tests covering the durable deal storage workflow
- stabilize the Next.js build by skipping the lockfile patch step, wrapping the build command, and fixing the RecordRow export type

## Testing
- npx tsc --noEmit
- npm run build
- npx jest app/api/hubspot/upload/__tests__/storage.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cfb23bc5a0832f925a2822c6d5e731