### PR TITLE
Configure CI pipeline for PostgreSQL

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,20 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     env:
       HARVEST_ACCESS_TOKEN: dummy_harvest_access_token
       HARVEST_ACCOUNT_ID: dummy_harvest_account_id
@@ -33,6 +47,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Setup Test Database
+        run: |
+          npm run migrate
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+
       - name: Run ESLint
         run: npm run lint
 
@@ -41,6 +61,9 @@ jobs:
 
       - name: Run unit tests
         run: npm test -- --coverage --passWithNoTests
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+          NODE_ENV: test
 
       - name: Upload coverage report
         if: always()
@@ -58,6 +81,8 @@ jobs:
 
       - name: Build API
         run: npm run build:api # compiles Express API to dist for deployment
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
 
       - name: Upload API build artifact
         uses: actions/upload-artifact@v3
@@ -67,6 +92,8 @@ jobs:
 
       - name: Build application for Lighthouse
         run: npm run build
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
 
   lighthouse:
     if: ${{ secrets.LHCI_GITHUB_APP_TOKEN != '' }}


### PR DESCRIPTION
## Summary
- add a PostgreSQL 14 service container to the CI job so migrations and tests can connect to a live database
- run the database migration before tests and supply a test DATABASE_URL for the test, build:api, and build steps

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build:api`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cfb731bbd8832f87aaac6539a4743c