### PR TITLE
Handle Harvest pagination for all resources

### DIFF
--- a/src/connectors/__tests__/harvest.connector.test.ts
+++ b/src/connectors/__tests__/harvest.connector.test.ts
@@ -28,6 +28,268 @@ describe('HarvestConnector', () => {
     expect(getMock).toHaveBeenCalledWith('/company');
   });
 
+  it('getTimeEntries accumulates paginated results', async () => {
+    const getMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          time_entries: [
+            {
+              id: 1,
+              spent_date: '2023-01-01',
+              client: { name: 'Client 1' },
+              project: { name: 'Project 1' },
+              task: { name: 'Task 1' },
+              notes: 'First entry',
+              hours: 1,
+              billable: true,
+              is_locked: false,
+              user: { first_name: 'John', last_name: 'Doe' },
+              user_assignment: { role: 'Engineer' },
+              billable_rate: 100,
+              cost_rate: 50,
+              external_reference: { id: 'ext-1' },
+            },
+          ],
+          next_page: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          time_entries: [
+            {
+              id: 2,
+              spent_date: '2023-01-02',
+              client: { name: 'Client 2' },
+              project: { name: 'Project 2' },
+              task: { name: 'Task 2' },
+              notes: 'Second entry',
+              hours: 2,
+              billable: false,
+              is_locked: true,
+              user: { first_name: 'Jane', last_name: 'Smith' },
+              user_assignment: { role: 'Designer' },
+              billable_rate: 200,
+              cost_rate: 75,
+              external_reference: { id: 'ext-2' },
+            },
+          ],
+          next_page: null,
+        },
+      });
+    (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+    const connector = new HarvestConnector();
+    const from = new Date('2023-01-01');
+    const to = new Date('2023-01-31');
+
+    const entries = await connector.getTimeEntries(from, to);
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].entryId).toBe('1');
+    expect(entries[1].entryId).toBe('2');
+    expect(getMock).toHaveBeenNthCalledWith(1, '/time_entries', {
+      params: {
+        from: '2023-01-01',
+        to: '2023-01-31',
+        per_page: 100,
+        page: 1,
+      },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/time_entries', {
+      params: {
+        from: '2023-01-01',
+        to: '2023-01-31',
+        per_page: 100,
+        page: 2,
+      },
+    });
+  });
+
+  it('getProjects accumulates paginated results', async () => {
+    const getMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          projects: [{ id: 1, name: 'Project 1', code: 'P1', client: { id: 11 }, is_active: true }],
+          next_page: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          projects: [{ id: 2, name: 'Project 2', code: 'P2', client_id: 22, is_active: false }],
+          next_page: null,
+        },
+      });
+    (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+    const connector = new HarvestConnector();
+    const projects = await connector.getProjects();
+
+    expect(projects).toEqual([
+      { id: 1, name: 'Project 1', code: 'P1', clientId: 11, isActive: true },
+      { id: 2, name: 'Project 2', code: 'P2', clientId: 22, isActive: false },
+    ]);
+    expect(getMock).toHaveBeenNthCalledWith(1, '/projects', {
+      params: { is_active: true, per_page: 100, page: 1 },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/projects', {
+      params: { is_active: true, per_page: 100, page: 2 },
+    });
+  });
+
+  it('getClients accumulates paginated results', async () => {
+    const getMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          clients: [{ id: 1, name: 'Client 1', is_active: true }],
+          next_page: 3,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          clients: [{ id: 2, name: 'Client 2', is_active: false }],
+          next_page: null,
+        },
+      });
+    (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+    const connector = new HarvestConnector();
+    const clients = await connector.getClients();
+
+    expect(clients).toEqual([
+      { id: 1, name: 'Client 1', isActive: true },
+      { id: 2, name: 'Client 2', isActive: false },
+    ]);
+    expect(getMock).toHaveBeenNthCalledWith(1, '/clients', {
+      params: { is_active: true, per_page: 100, page: 1 },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/clients', {
+      params: { is_active: true, per_page: 100, page: 3 },
+    });
+  });
+
+  it('getTasks accumulates paginated results', async () => {
+    const getMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          tasks: [
+            {
+              id: 1,
+              name: 'Task 1',
+              billable_by_default: true,
+              default_hourly_rate: 100,
+              is_active: true,
+            },
+          ],
+          next_page: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          tasks: [
+            {
+              id: 2,
+              name: 'Task 2',
+              billable_by_default: false,
+              default_hourly_rate: 200,
+              is_active: false,
+            },
+          ],
+          next_page: null,
+        },
+      });
+    (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+    const connector = new HarvestConnector();
+    const tasks = await connector.getTasks();
+
+    expect(tasks).toEqual([
+      {
+        id: 1,
+        name: 'Task 1',
+        billableByDefault: true,
+        defaultHourlyRate: 100,
+        isActive: true,
+      },
+      {
+        id: 2,
+        name: 'Task 2',
+        billableByDefault: false,
+        defaultHourlyRate: 200,
+        isActive: false,
+      },
+    ]);
+    expect(getMock).toHaveBeenNthCalledWith(1, '/tasks', {
+      params: { per_page: 100, page: 1 },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/tasks', {
+      params: { per_page: 100, page: 2 },
+    });
+  });
+
+  it('getUsers accumulates paginated results', async () => {
+    const getMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: {
+          users: [
+            {
+              id: 1,
+              first_name: 'John',
+              last_name: 'Doe',
+              email: 'john@example.com',
+              is_active: true,
+            },
+          ],
+          next_page: 5,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          users: [
+            {
+              id: 2,
+              first_name: 'Jane',
+              last_name: 'Smith',
+              email: 'jane@example.com',
+              is_active: false,
+            },
+          ],
+          next_page: null,
+        },
+      });
+    (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+    const connector = new HarvestConnector();
+    const users = await connector.getUsers();
+
+    expect(users).toEqual([
+      {
+        id: 1,
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john@example.com',
+        isActive: true,
+      },
+      {
+        id: 2,
+        firstName: 'Jane',
+        lastName: 'Smith',
+        email: 'jane@example.com',
+        isActive: false,
+      },
+    ]);
+    expect(getMock).toHaveBeenNthCalledWith(1, '/users', {
+      params: { is_active: true, per_page: 100, page: 1 },
+    });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/users', {
+      params: { is_active: true, per_page: 100, page: 5 },
+    });
+  });
+
   it('throws an error when HARVEST_ACCESS_TOKEN is missing', () => {
     delete process.env.HARVEST_ACCESS_TOKEN;
     expect(() => new HarvestConnector()).toThrow('HARVEST_ACCESS_TOKEN is not set');

--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -54,20 +54,18 @@ export class HarvestConnector {
       if (clientId) params.client_id = clientId;
       if (projectId) params.project_id = projectId;
 
-      let allEntries: HarvestTimeEntry[] = [];
-      let page = 1;
-      let hasMore = true;
+      const allEntries: HarvestTimeEntry[] = [];
+      let page: number | null = 1;
 
-      while (hasMore) {
+      while (page !== null) {
         const response = await this.client.get('/time_entries', {
           params: { ...params, page },
         });
 
         const entries = response.data.time_entries.map(this.mapTimeEntry);
-        allEntries = [...allEntries, ...entries];
+        allEntries.push(...entries);
 
-        hasMore = response.data.next_page !== null;
-        page++;
+        page = response.data.next_page;
       }
 
       return allEntries;
@@ -85,16 +83,28 @@ export class HarvestConnector {
 
   async getProjects(isActive = true): Promise<HarvestProject[]> {
     try {
-      const response = await this.client.get('/projects', {
-        params: { is_active: isActive, per_page: 100 },
-      });
-      return response.data.projects.map((p: any) => ({
-        id: p.id,
-        name: p.name,
-        code: p.code,
-        clientId: p.client?.id ?? p.client_id,
-        isActive: p.is_active,
-      }));
+      const projects: HarvestProject[] = [];
+      let page: number | null = 1;
+
+      while (page !== null) {
+        const response = await this.client.get('/projects', {
+          params: { is_active: isActive, per_page: 100, page },
+        });
+
+        projects.push(
+          ...response.data.projects.map((p: any) => ({
+            id: p.id,
+            name: p.name,
+            code: p.code,
+            clientId: p.client?.id ?? p.client_id,
+            isActive: p.is_active,
+          }))
+        );
+
+        page = response.data.next_page;
+      }
+
+      return projects;
     } catch (error) {
       captureException(error, {
         operation: 'HarvestConnector.getProjects',
@@ -106,14 +116,26 @@ export class HarvestConnector {
 
   async getClients(isActive = true): Promise<HarvestClient[]> {
     try {
-      const response = await this.client.get('/clients', {
-        params: { is_active: isActive, per_page: 100 },
-      });
-      return response.data.clients.map((c: any) => ({
-        id: c.id,
-        name: c.name,
-        isActive: c.is_active,
-      }));
+      const clients: HarvestClient[] = [];
+      let page: number | null = 1;
+
+      while (page !== null) {
+        const response = await this.client.get('/clients', {
+          params: { is_active: isActive, per_page: 100, page },
+        });
+
+        clients.push(
+          ...response.data.clients.map((c: any) => ({
+            id: c.id,
+            name: c.name,
+            isActive: c.is_active,
+          }))
+        );
+
+        page = response.data.next_page;
+      }
+
+      return clients;
     } catch (error) {
       captureException(error, {
         operation: 'HarvestConnector.getClients',
@@ -125,16 +147,28 @@ export class HarvestConnector {
 
   async getTasks(): Promise<HarvestTask[]> {
     try {
-      const response = await this.client.get('/tasks', {
-        params: { per_page: 100 },
-      });
-      return response.data.tasks.map((t: any) => ({
-        id: t.id,
-        name: t.name,
-        billableByDefault: t.billable_by_default,
-        defaultHourlyRate: t.default_hourly_rate,
-        isActive: t.is_active,
-      }));
+      const tasks: HarvestTask[] = [];
+      let page: number | null = 1;
+
+      while (page !== null) {
+        const response = await this.client.get('/tasks', {
+          params: { per_page: 100, page },
+        });
+
+        tasks.push(
+          ...response.data.tasks.map((t: any) => ({
+            id: t.id,
+            name: t.name,
+            billableByDefault: t.billable_by_default,
+            defaultHourlyRate: t.default_hourly_rate,
+            isActive: t.is_active,
+          }))
+        );
+
+        page = response.data.next_page;
+      }
+
+      return tasks;
     } catch (error) {
       captureException(error, {
         operation: 'HarvestConnector.getTasks',
@@ -145,16 +179,28 @@ export class HarvestConnector {
 
   async getUsers(isActive = true): Promise<HarvestUser[]> {
     try {
-      const response = await this.client.get('/users', {
-        params: { is_active: isActive, per_page: 100 },
-      });
-      return response.data.users.map((u: any) => ({
-        id: u.id,
-        firstName: u.first_name,
-        lastName: u.last_name,
-        email: u.email,
-        isActive: u.is_active,
-      }));
+      const users: HarvestUser[] = [];
+      let page: number | null = 1;
+
+      while (page !== null) {
+        const response = await this.client.get('/users', {
+          params: { is_active: isActive, per_page: 100, page },
+        });
+
+        users.push(
+          ...response.data.users.map((u: any) => ({
+            id: u.id,
+            firstName: u.first_name,
+            lastName: u.last_name,
+            email: u.email,
+            isActive: u.is_active,
+          }))
+        );
+
+        page = response.data.next_page;
+      }
+
+      return users;
     } catch (error) {
       captureException(error, {
         operation: 'HarvestConnector.getUsers',


### PR DESCRIPTION
## Summary
- update Harvest connector list endpoints to iterate through all paginated results
- add Jest coverage ensuring each connector method accumulates multiple pages of Harvest data

## Testing
- npm test -- harvest.connector

------
https://chatgpt.com/codex/tasks/task_e_68cfe1910488832fb9e7748c7d261e30