### PR TITLE
Improve Harvest retry resilience and surface metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,33 @@ DATABASE_URL=postgresql://user:password@localhost:5432/am_copilot
 # API Keys
 HARVEST_ACCESS_TOKEN=your_harvest_token
 HARVEST_ACCOUNT_ID=your_account_id
+HARVEST_RETRY_MAX_ATTEMPTS=5
+HARVEST_RETRY_BASE_DELAY_MS=1000
+HARVEST_RETRY_MAX_DELAY_MS=60000
 HUBSPOT_API_KEY=your_hubspot_key
 
 # Optional
 SENTRY_DSN=your_sentry_dsn
 NEXT_PUBLIC_API_URL=http://localhost:3001
 ```
+
+### Harvest API retry policy
+
+The Harvest connector automatically retries `getTimeEntries` requests when Harvest returns `429` (rate limited) or `503` (service unavailable) responses. The retry logic:
+
+- honors the `Retry-After` header when provided and waits at least that long before retrying
+- applies exponential backoff between attempts and caps the delay at a configurable maximum
+- aborts when the configured maximum number of attempts is reached, surfacing retry metrics in the API response
+
+You can tune the behaviour with environment variables:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `HARVEST_RETRY_MAX_ATTEMPTS` | Maximum attempts per Harvest request (including the first call). | `5` |
+| `HARVEST_RETRY_BASE_DELAY_MS` | Initial wait time (ms) before the first retry. | `1000` |
+| `HARVEST_RETRY_MAX_DELAY_MS` | Maximum wait time (ms) applied between retries. | `60000` |
+
+Responses from `/api/sync/harvest` include retry metrics so operators can tell when retries were used or exhausted.
 
 ## Development
 

--- a/src/connectors/__tests__/harvest.connector.test.ts
+++ b/src/connectors/__tests__/harvest.connector.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { HarvestConnector } from '../harvest.connector';
+import { HarvestConnector, HarvestRetryError } from '../harvest.connector';
 
 jest.mock('axios');
 
@@ -12,11 +12,15 @@ describe('HarvestConnector', () => {
       HARVEST_ACCESS_TOKEN: 'token',
       HARVEST_ACCOUNT_ID: 'account',
     };
+    (axios.isAxiosError as jest.Mock).mockImplementation((error: unknown) => {
+      return Boolean((error as any)?.isAxiosError);
+    });
   });
 
   afterEach(() => {
     process.env = originalEnv;
     jest.resetAllMocks();
+    jest.useRealTimers();
   });
 
   it('testConnection returns true on success', async () => {
@@ -36,6 +40,105 @@ describe('HarvestConnector', () => {
   it('throws an error when HARVEST_ACCOUNT_ID is missing', () => {
     delete process.env.HARVEST_ACCOUNT_ID;
     expect(() => new HarvestConnector()).toThrow('HARVEST_ACCOUNT_ID is not set');
+  });
+
+  describe('getTimeEntries', () => {
+    const baseResponse = {
+      data: { time_entries: [], next_page: null },
+    };
+
+    const createAxiosRateError = (status: number, headers: Record<string, string> = {}) => ({
+      isAxiosError: true,
+      response: { status, headers },
+      toJSON: () => ({}),
+    });
+
+    it('retries when rate limited and respects Retry-After header', async () => {
+      jest.useFakeTimers();
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+      const getMock = jest
+        .fn()
+        .mockRejectedValueOnce(createAxiosRateError(429, { 'retry-after': '3' }))
+        .mockResolvedValue(baseResponse);
+
+      (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+      const connector = new HarvestConnector();
+
+      const promise = connector.getTimeEntries(new Date('2024-01-01'), new Date('2024-01-02'));
+
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(3000);
+
+      const result = await promise;
+      const delays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+
+      expect(result.entries).toHaveLength(0);
+      expect(result.retry.attempts).toBe(2);
+      expect(result.retry.totalDelayMs).toBe(3000);
+      expect(result.retry.lastStatusCode).toBe(429);
+      expect(delays).toEqual([3000]);
+
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('applies capped exponential backoff for repeated failures', async () => {
+      jest.useFakeTimers();
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
+      const getMock = jest
+        .fn()
+        .mockRejectedValueOnce(createAxiosRateError(503))
+        .mockRejectedValueOnce(createAxiosRateError(503))
+        .mockResolvedValue(baseResponse);
+
+      (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+      const connector = new HarvestConnector();
+
+      const promise = connector.getTimeEntries(
+        new Date('2024-01-01'),
+        new Date('2024-01-02'),
+        undefined,
+        undefined,
+        { baseDelayMs: 100, maxDelayMs: 150, maxAttempts: 4 }
+      );
+
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(100);
+      await jest.advanceTimersByTimeAsync(150);
+
+      const result = await promise;
+      const delays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+
+      expect(result.retry.attempts).toBe(3);
+      expect(result.retry.totalDelayMs).toBe(250);
+      expect(result.retry.lastDelayMs).toBe(150);
+      expect(result.retry.lastStatusCode).toBe(503);
+      expect(delays).toEqual([100, 150]);
+
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('throws HarvestRetryError when retry attempts are exhausted', async () => {
+      jest.useFakeTimers();
+
+      const getMock = jest.fn().mockRejectedValue(createAxiosRateError(503));
+      (axios.create as jest.Mock).mockReturnValue({ get: getMock });
+
+      const connector = new HarvestConnector();
+
+      const promise = connector.getTimeEntries(
+        new Date('2024-01-01'),
+        new Date('2024-01-02'),
+        undefined,
+        undefined,
+        { maxAttempts: 1, baseDelayMs: 100 }
+      );
+
+      await expect(promise).rejects.toBeInstanceOf(HarvestRetryError);
+    });
   });
 });
 

--- a/src/connectors/harvest.connector.ts
+++ b/src/connectors/harvest.connector.ts
@@ -10,11 +10,45 @@ import {
 import { format, startOfMonth, endOfMonth } from 'date-fns';
 import { captureException } from '../utils/sentry';
 
+export interface HarvestRetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export interface HarvestRetryMetrics {
+  attempts: number;
+  maxAttempts: number;
+  totalDelayMs: number;
+  lastDelayMs: number;
+  lastStatusCode?: number;
+}
+
+export class HarvestRetryError extends Error {
+  constructor(message: string, public readonly retry: HarvestRetryMetrics) {
+    super(message);
+    this.name = 'HarvestRetryError';
+  }
+}
+
+const DEFAULT_RETRY_CONFIG: HarvestRetryConfig = {
+  maxAttempts: 5,
+  baseDelayMs: 1000,
+  maxDelayMs: 60_000,
+};
+
+const parseEnvInt = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? undefined : parsed;
+};
+
 export class HarvestConnector {
   private client: AxiosInstance;
   private accountId: string;
+  private retryConfig: HarvestRetryConfig;
 
-  constructor() {
+  constructor(config?: Partial<HarvestRetryConfig>) {
     const accessToken = process.env.HARVEST_ACCESS_TOKEN;
     const accountId = process.env.HARVEST_ACCOUNT_ID;
 
@@ -27,6 +61,30 @@ export class HarvestConnector {
     }
 
     this.accountId = accountId;
+
+    const envConfigEntries = (
+      [
+        ['maxAttempts', process.env.HARVEST_RETRY_MAX_ATTEMPTS],
+        ['baseDelayMs', process.env.HARVEST_RETRY_BASE_DELAY_MS],
+        ['maxDelayMs', process.env.HARVEST_RETRY_MAX_DELAY_MS],
+      ] as const
+    )
+      .map(([key, value]) => {
+        const parsed = parseEnvInt(value);
+        return parsed ? ([key, parsed] as const) : undefined;
+      })
+      .filter((entry): entry is readonly [keyof HarvestRetryConfig, number] => Boolean(entry));
+
+    const envConfig = Object.fromEntries(envConfigEntries) as Partial<HarvestRetryConfig>;
+
+    const mergedConfig = { ...DEFAULT_RETRY_CONFIG, ...envConfig, ...config };
+
+    // Ensure base delay never exceeds max delay and attempts is at least 1
+    this.retryConfig = {
+      maxAttempts: Math.max(1, mergedConfig.maxAttempts),
+      baseDelayMs: Math.max(1, Math.min(mergedConfig.baseDelayMs, mergedConfig.maxDelayMs)),
+      maxDelayMs: Math.max(mergedConfig.baseDelayMs, mergedConfig.maxDelayMs),
+    };
 
     this.client = axios.create({
       baseURL: 'https://api.harvestapp.com/v2',
@@ -42,9 +100,29 @@ export class HarvestConnector {
     fromDate: Date,
     toDate: Date,
     clientId?: string,
-    projectId?: string
-  ): Promise<HarvestTimeEntry[]> {
+    projectId?: string,
+    retryOverride?: Partial<HarvestRetryConfig>
+  ): Promise<{ entries: HarvestTimeEntry[]; retry: HarvestRetryMetrics }> {
     try {
+      const sanitizedOverride = retryOverride
+        ? Object.fromEntries(
+            Object.entries(retryOverride).filter(([, value]) => {
+              return typeof value === 'number' && Number.isFinite(value) && value > 0;
+            })
+          )
+        : {};
+
+      const retryConfig: HarvestRetryConfig = {
+        ...this.retryConfig,
+        ...(sanitizedOverride as Partial<HarvestRetryConfig>),
+      };
+
+      const effectiveRetryConfig: HarvestRetryConfig = {
+        maxAttempts: Math.max(1, retryConfig.maxAttempts),
+        baseDelayMs: Math.max(1, Math.min(retryConfig.baseDelayMs, retryConfig.maxDelayMs)),
+        maxDelayMs: Math.max(retryConfig.baseDelayMs, retryConfig.maxDelayMs),
+      };
+
       const params: Record<string, unknown> = {
         from: format(fromDate, 'yyyy-MM-dd'),
         to: format(toDate, 'yyyy-MM-dd'),
@@ -58,10 +136,64 @@ export class HarvestConnector {
       let page = 1;
       let hasMore = true;
 
+      let totalAttempts = 0;
+      let totalDelayMs = 0;
+      let lastDelayMs = 0;
+      let lastStatusCode: number | undefined;
+
+      const executeWithRetry = async () => {
+        let attempt = 0;
+        let delayMs = effectiveRetryConfig.baseDelayMs;
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          try {
+            totalAttempts += 1;
+            return await this.client.get('/time_entries', {
+              params: { ...params, page },
+            });
+          } catch (error) {
+            if (!axios.isAxiosError(error)) {
+              throw error;
+            }
+
+            const status = error.response?.status;
+            if (status !== 429 && status !== 503) {
+              throw error;
+            }
+
+            lastStatusCode = status;
+            attempt += 1;
+
+            if (attempt >= effectiveRetryConfig.maxAttempts) {
+              throw new HarvestRetryError('Harvest API retries exhausted', {
+                attempts: totalAttempts,
+                maxAttempts: effectiveRetryConfig.maxAttempts,
+                totalDelayMs,
+                lastDelayMs,
+                lastStatusCode: status,
+              });
+            }
+
+            const retryAfterHeader = error.response?.headers?.['retry-after'];
+            const retryAfterMs = this.parseRetryAfter(retryAfterHeader);
+            const waitMs = Math.min(
+              effectiveRetryConfig.maxDelayMs,
+              Math.max(delayMs, retryAfterMs ?? 0)
+            );
+
+            lastDelayMs = waitMs;
+            totalDelayMs += waitMs;
+
+            await this.delay(waitMs);
+
+            delayMs = Math.min(delayMs * 2, effectiveRetryConfig.maxDelayMs);
+          }
+        }
+      };
+
       while (hasMore) {
-        const response = await this.client.get('/time_entries', {
-          params: { ...params, page },
-        });
+        const response = await executeWithRetry();
 
         const entries = response.data.time_entries.map(this.mapTimeEntry);
         allEntries = [...allEntries, ...entries];
@@ -70,7 +202,16 @@ export class HarvestConnector {
         page++;
       }
 
-      return allEntries;
+      return {
+        entries: allEntries,
+        retry: {
+          attempts: totalAttempts,
+          maxAttempts: effectiveRetryConfig.maxAttempts,
+          totalDelayMs,
+          lastDelayMs,
+          lastStatusCode,
+        },
+      };
     } catch (error) {
       captureException(error, {
         operation: 'HarvestConnector.getTimeEntries',
@@ -189,7 +330,8 @@ export class HarvestConnector {
     const now = new Date();
     const fromDate = startOfMonth(now);
     const toDate = endOfMonth(now);
-    return this.getTimeEntries(fromDate, toDate, clientId);
+    const result = await this.getTimeEntries(fromDate, toDate, clientId);
+    return result.entries;
   }
 
   private mapTimeEntry(entry: HarvestTimeEntryApiResponse): HarvestTimeEntry {
@@ -225,5 +367,30 @@ export class HarvestConnector {
       });
       return false;
     }
+  }
+
+  private async delay(ms: number) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private parseRetryAfter(headerValue: unknown): number | undefined {
+    if (typeof headerValue === 'number') {
+      return headerValue * 1000;
+    }
+
+    if (typeof headerValue === 'string') {
+      const numeric = Number.parseFloat(headerValue);
+      if (!Number.isNaN(numeric)) {
+        return numeric * 1000;
+      }
+
+      const date = Date.parse(headerValue);
+      if (!Number.isNaN(date)) {
+        const now = Date.now();
+        return Math.max(0, date - now);
+      }
+    }
+
+    return undefined;
   }
 }


### PR DESCRIPTION
## Summary
- add configurable retry/backoff handling to the Harvest connector and expose retry metrics
- propagate retry configuration and metadata through the Harvest sync route
- extend test coverage for Harvest retry behaviour and document the retry policy and env vars

## Testing
- npm test -- src/connectors/__tests__/harvest.connector.test.ts --runInBand
- npm test -- src/api/__tests__/api.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cfe192466c832fb1ffd4270282434f