### PR TITLE
Add Express auth guard and rate limiting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import createApiRouter from './api/routes';
 import { AppError } from './types';
+import { createRateLimitMiddleware, requireExpressAuth } from './middleware/expressAuth';
 
 const app = express();
 
@@ -11,7 +12,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // API routes
-app.use('/api', createApiRouter());
+const apiLimiter = createRateLimitMiddleware({ scope: 'api' });
+app.use('/api', apiLimiter, requireExpressAuth, createApiRouter());
 
 // Error handling middleware
 app.use((err: AppError, req: Request, res: Response, _next: NextFunction) => {

--- a/src/middleware/expressAuth.ts
+++ b/src/middleware/expressAuth.ts
@@ -1,0 +1,119 @@
+import { Request, Response, NextFunction } from 'express';
+import { checkRateLimit, isApiKeyAuthorized, isSessionTokenAuthorized } from './auth';
+
+export interface RateLimitOptions {
+  limit?: number;
+  windowMs?: number;
+  /**
+   * Optional prefix to namespace identifiers so multiple limiters
+   * do not interfere with each other.
+   */
+  scope?: string;
+  keyGenerator?: (req: Request) => string | null;
+}
+
+const DEFAULT_LIMIT = 100;
+const DEFAULT_WINDOW_MS = 60_000;
+
+function getForwardedAddress(header: string | string[] | undefined): string | null {
+  if (!header) {
+    return null;
+  }
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) {
+    return null;
+  }
+  return value.split(',')[0]?.trim() ?? null;
+}
+
+function defaultKeyGenerator(req: Request): string | null {
+  return (
+    getForwardedAddress(req.headers['x-forwarded-for']) ||
+    req.ip ||
+    req.socket.remoteAddress ||
+    null
+  );
+}
+
+function parseCookie(header: string | undefined, name: string): string | undefined {
+  if (!header) {
+    return undefined;
+  }
+
+  const cookies = header.split(';');
+  for (const cookie of cookies) {
+    const [rawName, ...rest] = cookie.split('=');
+    if (rawName?.trim() === name) {
+      return rest.join('=').trim();
+    }
+  }
+  return undefined;
+}
+
+function getSessionToken(req: Request): string | undefined {
+  const fromCookieParser = (req as Request & { cookies?: Record<string, string> }).cookies?.['session-token'];
+  if (fromCookieParser) {
+    return fromCookieParser;
+  }
+  return parseCookie(req.headers.cookie, 'session-token');
+}
+
+function normalizeHeaderValue(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function requireExpressAuth(req: Request, res: Response, next: NextFunction): void {
+  const apiKey = normalizeHeaderValue(req.headers['x-api-key']);
+  if (isApiKeyAuthorized(apiKey)) {
+    next();
+    return;
+  }
+
+  const sessionToken = getSessionToken(req);
+  if (isSessionTokenAuthorized(sessionToken)) {
+    next();
+    return;
+  }
+
+  res.status(401).json({
+    error: 'Unauthorized',
+    message: 'Valid authentication required to access this endpoint',
+  });
+}
+
+export function createRateLimitMiddleware(options: RateLimitOptions = {}) {
+  const {
+    limit = DEFAULT_LIMIT,
+    windowMs = DEFAULT_WINDOW_MS,
+    scope,
+    keyGenerator = defaultKeyGenerator,
+  } = options;
+
+  return function rateLimitMiddleware(req: Request, res: Response, next: NextFunction): void {
+    const key = keyGenerator(req);
+    if (!key) {
+      next();
+      return;
+    }
+
+    const identifier = scope ? `${scope}:${key}` : key;
+    const allowed = checkRateLimit(identifier, limit, windowMs);
+    if (allowed) {
+      next();
+      return;
+    }
+
+    res.setHeader('Retry-After', Math.ceil(windowMs / 1000).toString());
+    res.status(429).json({
+      error: 'Too Many Requests',
+      message: 'Rate limit exceeded. Please try again later.',
+    });
+  };
+}
+
+export function getClientIdentifier(req: Request): string {
+  return defaultKeyGenerator(req) ?? 'unknown';
+}


### PR DESCRIPTION
## Summary
- add an Express middleware that authenticates API key or session tokens and exposes reusable rate limiting utilities
- enforce per-IP limiting on the API router and throttle expensive sync, export, and exception handlers
- expand backend API tests with auth success/failure and rate limit assertions

## Testing
- npm test -- src/api/__tests__/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cff0fddcd8832facebc97279726eac