### PR TITLE
Map Harvest IDs to local entities and sync profitability data

### DIFF
--- a/src/api/__tests__/api.test.ts
+++ b/src/api/__tests__/api.test.ts
@@ -29,7 +29,19 @@ describe('API endpoints', () => {
 
     harvestConnector = {
       getTimeEntries: jest.fn().mockResolvedValue([
-        { entryId: '1', date: new Date(), hours: 1, billableFlag: true, notes: 'test' }
+        {
+          entryId: '1',
+          date: new Date(),
+          hours: 1,
+          billableFlag: true,
+          notes: 'test',
+          clientId: null,
+          projectId: null,
+          taskId: null,
+          personId: null,
+          billableAmount: 0,
+          costAmount: 0,
+        }
       ])
     } as any;
     hubspotConnector = {
@@ -79,6 +91,12 @@ describe('API endpoints', () => {
       hours: 1,
       billableFlag: true,
       notes: 'test',
+      clientId: null,
+      projectId: null,
+      taskId: null,
+      personId: null,
+      billableAmount: 0,
+      costAmount: 0,
     }));
 
     harvestConnector.getTimeEntries.mockResolvedValue(entries);
@@ -105,7 +123,7 @@ describe('API endpoints', () => {
     insertCalls.forEach((call, index) => {
       const params = call[1] as unknown[];
       const expectedLength =
-        index < fullChunks ? DEFAULT_BATCH_SIZE * 5 : remainder * 5;
+        index < fullChunks ? DEFAULT_BATCH_SIZE * 11 : remainder * 11;
       expect(params).toHaveLength(expectedLength);
     });
 

--- a/src/api/sync/routes.ts
+++ b/src/api/sync/routes.ts
@@ -66,17 +66,42 @@ export default function createSyncRouter({
             entry.hours,
             entry.billableFlag,
             entry.notes,
+            entry.clientId ?? null,
+            entry.projectId ?? null,
+            entry.taskId ?? null,
+            entry.personId ?? null,
+            entry.billableAmount,
+            entry.costAmount,
           ]);
 
           await batchInsert(
             client,
             'time_entries',
-            ['harvest_entry_id', 'date', 'hours', 'billable_flag', 'notes'],
+            [
+              'harvest_entry_id',
+              'date',
+              'hours',
+              'billable_flag',
+              'notes',
+              'client_id',
+              'project_id',
+              'task_id',
+              'person_id',
+              'billable_amount',
+              'cost_amount',
+            ],
             records,
             `ON CONFLICT (harvest_entry_id) DO UPDATE SET
+              date = EXCLUDED.date,
               hours = EXCLUDED.hours,
               billable_flag = EXCLUDED.billable_flag,
-              notes = EXCLUDED.notes`
+              notes = EXCLUDED.notes,
+              client_id = EXCLUDED.client_id,
+              project_id = EXCLUDED.project_id,
+              task_id = EXCLUDED.task_id,
+              person_id = EXCLUDED.person_id,
+              billable_amount = EXCLUDED.billable_amount,
+              cost_amount = EXCLUDED.cost_amount`
           );
         }
 

--- a/src/connectors/__tests__/harvest.connector.test.ts
+++ b/src/connectors/__tests__/harvest.connector.test.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import { HarvestConnector } from '../harvest.connector';
+import { query } from '../../models/database';
 
 jest.mock('axios');
+jest.mock('../../models/database', () => ({
+  query: jest.fn(),
+}));
 
 describe('HarvestConnector', () => {
   const originalEnv = process.env;
@@ -12,11 +16,13 @@ describe('HarvestConnector', () => {
       HARVEST_ACCESS_TOKEN: 'token',
       HARVEST_ACCOUNT_ID: 'account',
     };
+    (query as jest.MockedFunction<typeof query>).mockReset();
+    (query as jest.MockedFunction<typeof query>).mockResolvedValue({ rows: [] } as never);
   });
 
   afterEach(() => {
     process.env = originalEnv;
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('testConnection returns true on success', async () => {
@@ -82,6 +88,8 @@ describe('HarvestConnector', () => {
     const connector = new HarvestConnector();
     const from = new Date('2023-01-01');
     const to = new Date('2023-01-31');
+
+    (query as jest.MockedFunction<typeof query>).mockResolvedValue({ rows: [] } as never);
 
     const entries = await connector.getTimeEntries(from, to);
 

--- a/src/services/__tests__/profitability.service.test.ts
+++ b/src/services/__tests__/profitability.service.test.ts
@@ -81,4 +81,63 @@ describe('ProfitabilityService', () => {
       );
     });
   });
+
+  describe('calculateProfitability', () => {
+    it('aggregates cost amounts and stores metrics', async () => {
+      const queryMock = query as jest.MockedFunction<typeof query>;
+      queryMock
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              billable_cost: '120.50',
+              exclusion_cost: '30.25',
+              exception_count: '2',
+            },
+          ],
+        } as never)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              recognised_revenue: '500.75',
+            },
+          ],
+        } as never)
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              client_name: 'Client X',
+              project_name: 'Project Y',
+            },
+          ],
+        } as never)
+        .mockResolvedValueOnce({ rows: [] } as never);
+
+      const month = new Date('2024-02-01T00:00:00Z');
+      const expectedMarginPercentage = (350 / 500.75) * 100;
+      const metric = await service.calculateProfitability('client-uuid', 'project-uuid', month);
+
+      expect(metric).toEqual({
+        month: '2024-02',
+        client: 'Client X',
+        project: 'Project Y',
+        billableCost: 120.5,
+        exclusionCost: 30.25,
+        recognisedRevenue: 500.75,
+        margin: 350.0,
+        marginPercentage: expectedMarginPercentage,
+        exceptionsCount: 2,
+      });
+
+      expect(queryMock).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('SUM(CASE WHEN t.category = \'billable\' THEN te.cost_amount'),
+        ['client-uuid', 'project-uuid', month]
+      );
+      expect(queryMock).toHaveBeenNthCalledWith(
+        4,
+        expect.stringContaining('INSERT INTO profitability_metrics'),
+        expect.any(Array)
+      );
+    });
+  });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,10 @@ export interface HarvestTimeEntry {
   costAmount: number;
   currency: string;
   externalRef?: string;
+  clientId: string | null;
+  projectId: string | null;
+  taskId: string | null;
+  personId: string | null;
 }
 
 export interface SFTRevenue {
@@ -222,14 +226,18 @@ export interface TimeEntryRecord {
 export interface HarvestTimeEntryApiResponse {
   id: number;
   spent_date: string;
-  client?: { name: string };
-  project?: { name: string };
-  task?: { name: string };
+  client?: { id?: number; name: string };
+  client_id?: number;
+  project?: { id?: number; name: string };
+  project_id?: number;
+  task?: { id?: number; name: string };
+  task_id?: number;
   notes?: string;
   hours: number;
   billable: boolean;
   is_locked: boolean;
-  user?: { first_name: string; last_name: string };
+  user?: { id?: number; first_name: string; last_name: string };
+  user_id?: number;
   user_assignment?: { role: string };
   billable_rate?: number;
   cost_rate?: number;


### PR DESCRIPTION
## Summary
- cache Harvest client, project, task, and person lookups to translate API IDs into local UUIDs while enriching mapped time entries
- persist the resolved IDs plus billable and cost amounts during Harvest sync and update conflicting rows with the new data
- expand Harvest time entry typings and strengthen API/profitability tests to cover the new fields and cost aggregation

## Testing
- CI=true npx jest src/connectors/__tests__/harvest.connector.test.ts src/api/__tests__/api.test.ts src/services/__tests__/profitability.service.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cff107a3c8832fba87d84eec0fb244