### PR TITLE
Make sync rate limits configurable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,13 @@ List active projects for a client.
 ### `POST /api/sync/harvest`
 Sync time entries from Harvest.
 
+#### Rate limiting
+
+Sync routes share a rate limiter that allows 60 requests per minute by default. The
+thresholds can be overridden with the `SYNC_RATE_LIMIT` (number of requests) and
+`SYNC_RATE_WINDOW_MS` (window size in milliseconds) environment variables if your
+deployment needs a different throughput.
+
 **Request Schema**
 ```json
 {


### PR DESCRIPTION
## Summary
- raise sync route rate limiting defaults to 60 requests per minute and allow overrides through SYNC_RATE_LIMIT/SYNC_RATE_WINDOW_MS
- share the configurable limiter across Harvest, HubSpot, and SFT sync endpoints
- document the new defaults and environment variable controls in the API guide

## Testing
- npm test -- src/api/__tests__/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cff66fb3e0832fac66f9c0cf09e777