### PR TITLE
Fix harvest sync tests and Next route import

### DIFF
--- a/app/api/harvest/users/me/route.ts
+++ b/app/api/harvest/users/me/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { withAuth } from "../../middleware/auth";
+import { withAuth } from "../../../middleware/auth";
 
 export async function GET(req: NextRequest) {
   return withAuth(req, async () => {


### PR DESCRIPTION
## Summary
- allow injected Harvest connectors without metrics helpers to avoid runtime exceptions in the sync handler
- surface missing environment variable details when Harvest sync fails before initialisation
- correct the auth helper import path for the Next.js Harvest user route so the build succeeds

## Testing
- `npm test -- --runTestsByPath src/api/__tests__/api.test.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d052cb45d8832fb3fa5930de599433