### PR TITLE
Switch frontend auth to signed session cookies

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSessionToken, SESSION_COOKIE_NAME } from '../../../../../src/middleware/auth';
+
+interface LoginRequestBody {
+  username?: string;
+  password?: string;
+}
+
+export async function POST(request: NextRequest) {
+  let body: LoginRequestBody;
+
+  try {
+    body = (await request.json()) as LoginRequestBody;
+  } catch (error) {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { username, password } = body;
+
+  const expectedUsername = process.env.AUTH_USERNAME;
+  const expectedPassword = process.env.AUTH_PASSWORD;
+
+  if (!expectedUsername || !expectedPassword || !process.env.SESSION_SECRET) {
+    return NextResponse.json(
+      { error: 'Authentication is not configured on the server' },
+      { status: 500 }
+    );
+  }
+
+  if (!username || !password) {
+    return NextResponse.json({ error: 'Username and password are required' }, { status: 400 });
+  }
+
+  if (username !== expectedUsername || password !== expectedPassword) {
+    return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+  }
+
+  const session = await createSessionToken(username);
+  const maxAgeSeconds = Math.max(0, Math.floor((session.payload.exp - Date.now()) / 1000));
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.set({
+    name: SESSION_COOKIE_NAME,
+    value: session.token,
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: maxAgeSeconds,
+  });
+
+  return response;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,46 +1,28 @@
-import { NextResponse } from 'next/server';
-import type { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { SESSION_COOKIE_NAME, verifySessionToken } from './src/middleware/auth';
 
-/**
- * Global middleware for Next.js App Router
- * Enforces authentication on ALL /api/* routes
- */
-export function middleware(request: NextRequest) {
-  // Only apply to API routes
-  if (request.nextUrl.pathname.startsWith('/api')) {
-    // Check for API key
-    const apiKey = request.headers.get('x-api-key');
-    const expectedApiKey = process.env.INTERNAL_API_KEY;
-
-    if (expectedApiKey && apiKey === expectedApiKey) {
-      // Valid API key, allow request
-      return NextResponse.next();
-    }
-
-    // Check for session token (temporary - replace with real session management)
-    const sessionToken = request.cookies.get('session-token')?.value;
-    const validSessionToken = process.env.VALID_SESSION_TOKEN;
-
-    if (validSessionToken && sessionToken === validSessionToken) {
-      // Valid session, allow request
-      return NextResponse.next();
-    }
-
-    // No valid authentication
-    return NextResponse.json(
-      {
-        error: 'Unauthorized - API key or valid session required',
-        timestamp: new Date().toISOString()
-      },
-      { status: 401 }
-    );
+export async function middleware(request: NextRequest) {
+  if (!request.nextUrl.pathname.startsWith('/api')) {
+    return NextResponse.next();
   }
 
-  // Not an API route, allow request
-  return NextResponse.next();
+  const sessionToken = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  const payload = await verifySessionToken(sessionToken);
+
+  if (payload) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.json(
+    {
+      error: 'Unauthorized',
+      message: 'Valid session required',
+      timestamp: new Date().toISOString(),
+    },
+    { status: 401 }
+  );
 }
 
-// Configure which routes the middleware runs on
 export const config = {
-  matcher: '/api/:path*'
+  matcher: '/api/:path*',
 };

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,51 +1,178 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-/**
- * Returns true when the provided API key matches the configured INTERNAL_API_KEY
- */
-export function isApiKeyAuthorized(apiKey: string | null | undefined): boolean {
-  const expectedApiKey = process.env.INTERNAL_API_KEY;
-  return Boolean(expectedApiKey && apiKey && apiKey === expectedApiKey);
+const SESSION_COOKIE_NAME = 'session-token';
+const DEFAULT_SESSION_DURATION_MS = 1000 * 60 * 60 * 8; // 8 hours
+
+export interface SessionTokenPayload {
+  sub: string;
+  iat: number;
+  exp: number;
 }
 
-/**
- * Returns true when the provided session token matches the configured VALID_SESSION_TOKEN
- */
-export function isSessionTokenAuthorized(token: string | null | undefined): boolean {
-  const validSessionToken = process.env.VALID_SESSION_TOKEN;
-  return Boolean(validSessionToken && token && token === validSessionToken);
+interface SessionTokenResult {
+  token: string;
+  payload: SessionTokenPayload;
 }
 
-/**
- * Authentication middleware for API routes
- * Checks for valid API key or session
- */
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+let cachedSecret: string | null = null;
+let cachedKey: CryptoKey | null = null;
+
+function getCrypto(): Crypto {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) {
+    throw new Error('Web Crypto API is not available in this runtime');
+  }
+  return globalThis.crypto;
+}
+
+function base64UrlEncode(data: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < data.byteLength; i += 1) {
+    binary += String.fromCharCode(data[i]!);
+  }
+
+  const base64 =
+    typeof btoa === 'function'
+      ? btoa(binary)
+      : Buffer.from(binary, 'binary').toString('base64');
+
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+function base64UrlDecode(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+
+  const binary =
+    typeof atob === 'function'
+      ? atob(padded)
+      : Buffer.from(padded, 'base64').toString('binary');
+
+  const output = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    output[i] = binary.charCodeAt(i);
+  }
+  return output;
+}
+
+async function getHmacKey(secret: string): Promise<CryptoKey> {
+  if (cachedKey && cachedSecret === secret) {
+    return cachedKey;
+  }
+
+  const cryptoApi = getCrypto();
+  const key = await cryptoApi.subtle.importKey(
+    'raw',
+    textEncoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+
+  cachedSecret = secret;
+  cachedKey = key;
+  return key;
+}
+
+function decodePayload(data: Uint8Array): SessionTokenPayload {
+  const json = textDecoder.decode(data);
+  return JSON.parse(json) as SessionTokenPayload;
+}
+
+export async function createSessionToken(
+  subject: string,
+  ttlMs: number = DEFAULT_SESSION_DURATION_MS
+): Promise<SessionTokenResult> {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    throw new Error('SESSION_SECRET is not configured');
+  }
+
+  const issuedAt = Date.now();
+  const expiresAt = issuedAt + ttlMs;
+  const payload: SessionTokenPayload = {
+    sub: subject,
+    iat: issuedAt,
+    exp: expiresAt,
+  };
+
+  const payloadBytes = textEncoder.encode(JSON.stringify(payload));
+  const encodedPayload = base64UrlEncode(payloadBytes);
+  const cryptoApi = getCrypto();
+  const key = await getHmacKey(secret);
+  const signatureBuffer = await cryptoApi.subtle.sign('HMAC', key, textEncoder.encode(encodedPayload));
+  const signature = base64UrlEncode(new Uint8Array(signatureBuffer));
+
+  return {
+    token: `${encodedPayload}.${signature}`,
+    payload,
+  };
+}
+
+export async function verifySessionToken(
+  token: string | null | undefined
+): Promise<SessionTokenPayload | null> {
+  if (!token) {
+    return null;
+  }
+
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) {
+    return null;
+  }
+
+  const [encodedPayload, providedSignature] = token.split('.');
+  if (!encodedPayload || !providedSignature) {
+    return null;
+  }
+
+  try {
+    const cryptoApi = getCrypto();
+    const key = await getHmacKey(secret);
+    const isValid = await cryptoApi.subtle.verify(
+      'HMAC',
+      key,
+      base64UrlDecode(providedSignature),
+      textEncoder.encode(encodedPayload)
+    );
+
+    if (!isValid) {
+      return null;
+    }
+
+    const payloadBytes = base64UrlDecode(encodedPayload);
+    const payload = decodePayload(payloadBytes);
+
+    if (typeof payload.exp !== 'number' || Date.now() >= payload.exp) {
+      return null;
+    }
+
+    return payload;
+  } catch (error) {
+    console.error('Failed to verify session token', error);
+    return null;
+  }
+}
+
 export async function requireAuth(req: NextRequest): Promise<NextResponse | null> {
-  // Check for API key in headers
-  const apiKey = req.headers.get('x-api-key');
-  if (isApiKeyAuthorized(apiKey)) {
-    return null; // Authentication successful
+  const sessionCookie = req.cookies.get(SESSION_COOKIE_NAME)?.value;
+  const payload = await verifySessionToken(sessionCookie);
+
+  if (payload) {
+    return null;
   }
 
-  // Check for session cookie (if using session-based auth)
-  const sessionToken = req.cookies.get('session-token')?.value;
-  if (isSessionTokenAuthorized(sessionToken)) {
-    return null; // Authentication successful
-  }
-
-  // No valid authentication found
   return NextResponse.json(
     {
       error: 'Unauthorized',
-      message: 'Valid authentication required to access this endpoint'
+      message: 'Valid authentication required to access this endpoint',
     },
     { status: 401 }
   );
 }
 
-/**
- * Rate limiting check
- */
 const requestCounts = new Map<string, { count: number; resetTime: number }>();
 
 export function checkRateLimit(
@@ -65,13 +192,10 @@ export function checkRateLimit(
     return false;
   }
 
-  record.count++;
+  record.count += 1;
   return true;
 }
 
-/**
- * Clears stored rate limit counters. Useful for testing environments.
- */
 export function resetRateLimit(identifier?: string): void {
   if (identifier) {
     requestCounts.delete(identifier);
@@ -79,3 +203,5 @@ export function resetRateLimit(identifier?: string): void {
   }
   requestCounts.clear();
 }
+
+export { SESSION_COOKIE_NAME, DEFAULT_SESSION_DURATION_MS };

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -5,7 +5,6 @@
 
 interface ApiConfig {
   baseUrl?: string;
-  apiKey?: string;
   headers?: Record<string, string>;
 }
 
@@ -19,12 +18,6 @@ class ApiService {
       'Content-Type': 'application/json',
       ...config.headers,
     };
-
-    // Add API key if provided
-    const apiKey = config.apiKey || process.env.NEXT_PUBLIC_API_KEY;
-    if (apiKey) {
-      this.headers['x-api-key'] = apiKey;
-    }
   }
 
   private async request<T>(
@@ -36,6 +29,7 @@ class ApiService {
     try {
       const response = await fetch(url, {
         ...options,
+        credentials: options.credentials ?? 'include',
         headers: {
           ...this.headers,
           ...options.headers,

--- a/src/services/auth.client.ts
+++ b/src/services/auth.client.ts
@@ -1,0 +1,37 @@
+export interface LoginCredentials {
+  username: string;
+  password: string;
+}
+
+let activeLoginPromise: Promise<void> | null = null;
+
+async function performLogin(credentials: LoginCredentials): Promise<void> {
+  const response = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify(credentials),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({ error: 'Login failed' }));
+    throw new Error(errorBody.error ?? 'Login failed');
+  }
+}
+
+export function ensureAuthenticated(credentials: LoginCredentials): Promise<void> {
+  if (!activeLoginPromise) {
+    activeLoginPromise = performLogin(credentials).catch((error) => {
+      activeLoginPromise = null;
+      throw error;
+    });
+  }
+
+  return activeLoginPromise;
+}
+
+export function clearCachedLogin(): void {
+  activeLoginPromise = null;
+}


### PR DESCRIPTION
## Summary
- add HMAC-signed session cookies and shared verification helpers for API access
- add a secure login route plus client helper and use cookies across middleware and scripts
- update tests and tooling to drop API keys in favour of the new session authentication

## Testing
- npm test
- npm test -- src/api/__tests__/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0f8fec2d8832f990b80661ddb7d0b