### PR TITLE
Ensure client fetch requests include session credentials

### DIFF
--- a/app/components/DealsUploader.tsx
+++ b/app/components/DealsUploader.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Upload, FileText, Trash2, RefreshCw, Download, CheckCircle, AlertCircle } from 'lucide-react';
+import { fetchWithSession } from '../../src/utils/fetchWithSession';
 
 interface Deal {
   id?: string;
@@ -30,7 +31,7 @@ export default function DealsUploader() {
   const fetchDeals = async () => {
     setIsLoading(true);
     try {
-      const response = await fetch('/api/hubspot/upload');
+      const response = await fetchWithSession('/api/hubspot/upload');
       const data = await response.json();
       if (data.success) {
         setDeals(data.deals || []);
@@ -84,7 +85,7 @@ export default function DealsUploader() {
     formData.append('file', file);
 
     try {
-      const response = await fetch('/api/hubspot/upload', {
+      const response = await fetchWithSession('/api/hubspot/upload', {
         method: 'POST',
         body: formData,
       });
@@ -112,7 +113,7 @@ export default function DealsUploader() {
     if (!confirm('Are you sure you want to clear all imported deals?')) return;
 
     try {
-      const response = await fetch('/api/hubspot/upload', {
+      const response = await fetchWithSession('/api/hubspot/upload', {
         method: 'DELETE',
       });
 

--- a/app/components/HarvestSummary.tsx
+++ b/app/components/HarvestSummary.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import { Card, Flex, Text, Button } from '@radix-ui/themes';
 import Link from 'next/link';
 import { Clock, Calendar, TrendingUp } from 'lucide-react';
+import { fetchWithSession } from '../../src/utils/fetchWithSession';
 
 interface TimeEntrySummary {
   totalHours: number;
@@ -31,7 +32,7 @@ export function HarvestSummary() {
       const from = startOfWeek.toISOString().split('T')[0];
       const to = endOfWeek.toISOString().split('T')[0];
 
-      const response = await fetch(`/api/harvest/time-entries?from=${from}&to=${to}`);
+      const response = await fetchWithSession(`/api/harvest/time-entries?from=${from}&to=${to}`);
       
       if (response.ok) {
         const data = await response.json();

--- a/app/components/HubSpotDashboard.tsx
+++ b/app/components/HubSpotDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { fetchWithSession } from "../../src/utils/fetchWithSession";
 
 interface Contact {
   id: string;
@@ -54,7 +55,7 @@ export function HubSpotDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/hubspot/contacts?limit=50");
+      const response = await fetchWithSession("/api/hubspot/contacts?limit=50");
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Error: ${response.status}`);
@@ -74,7 +75,7 @@ export function HubSpotDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/hubspot/companies?limit=50");
+      const response = await fetchWithSession("/api/hubspot/companies?limit=50");
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Error: ${response.status}`);
@@ -94,7 +95,7 @@ export function HubSpotDashboard() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/hubspot/deals?limit=50");
+      const response = await fetchWithSession("/api/hubspot/deals?limit=50");
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Error: ${response.status}`);

--- a/app/components/HubSpotDashboardEnhanced.tsx
+++ b/app/components/HubSpotDashboardEnhanced.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from "react";
 import Link from "next/link";
 import { Upload } from "lucide-react";
+import { fetchWithSession } from "../../src/utils/fetchWithSession";
 
 interface Contact {
   id: string;
@@ -57,7 +58,7 @@ export function HubSpotDashboardEnhanced() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/hubspot/contacts?limit=50");
+      const response = await fetchWithSession("/api/hubspot/contacts?limit=50");
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Error: ${response.status}`);
@@ -77,7 +78,7 @@ export function HubSpotDashboardEnhanced() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("/api/hubspot/companies?limit=50");
+      const response = await fetchWithSession("/api/hubspot/companies?limit=50");
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.error || `Error: ${response.status}`);
@@ -100,11 +101,11 @@ export function HubSpotDashboardEnhanced() {
 
     try {
       // First try the HubSpot API
-      const response = await fetch("/api/hubspot/deals?limit=50");
+      const response = await fetchWithSession("/api/hubspot/deals?limit=50");
       if (!response.ok) {
         // If API fails, try to get uploaded deals
         console.warn("HubSpot API failed, checking for uploaded deals...");
-        const uploadResponse = await fetch("/api/hubspot/upload");
+        const uploadResponse = await fetchWithSession("/api/hubspot/upload");
         if (uploadResponse.ok) {
           const uploadData = await uploadResponse.json();
           if (uploadData.success && uploadData.deals.length > 0) {

--- a/app/components/TimeEntriesTable.tsx
+++ b/app/components/TimeEntriesTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { fetchWithSession } from "../../src/utils/fetchWithSession";
 
 interface TimeEntry {
   id: number;
@@ -51,7 +52,7 @@ export function TimeEntriesTable() {
     try {
       const url = `/api/harvest/time-entries?from=${from}&to=${to}&page=${page}`;
 
-      const response = await fetch(url, { cache: "no-store" });
+      const response = await fetchWithSession(url, { cache: "no-store" });
 
       if (!response.ok) {
         const errorText = await response.text();

--- a/app/components/TimeEntriesTableEnhanced.tsx
+++ b/app/components/TimeEntriesTableEnhanced.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { fetchWithSession } from "../../src/utils/fetchWithSession";
 
 interface TimeEntry {
   id: number;
@@ -54,7 +55,7 @@ export function TimeEntriesTableEnhanced() {
     try {
       const url = `/api/harvest/time-entries?from=${from}&to=${to}&page=${page}`;
 
-      const response = await fetch(url, { cache: "no-store" });
+      const response = await fetchWithSession(url, { cache: "no-store" });
 
       if (!response.ok) {
         const errorText = await response.text();

--- a/app/sentry-example-page/page.tsx
+++ b/app/sentry-example-page/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import * as Sentry from '@sentry/nextjs';
+import { fetchWithSession } from '../src/utils/fetchWithSession';
 
 export default function SentryExamplePage() {
   const [testType, setTestType] = useState<string>('');
@@ -16,7 +17,7 @@ export default function SentryExamplePage() {
   };
 
   const triggerAsyncError = async () => {
-    const response = await fetch('/api/non-existent-endpoint');
+    const response = await fetchWithSession('/api/non-existent-endpoint');
     if (!response.ok) {
       throw new Error(`API Error: ${response.status}`);
     }

--- a/src/services/api.service.ts
+++ b/src/services/api.service.ts
@@ -3,6 +3,8 @@
  * This service connects to actual backend endpoints with proper authentication
  */
 
+import { fetchWithSession } from '../utils/fetchWithSession';
+
 interface ApiConfig {
   baseUrl?: string;
   apiKey?: string;
@@ -34,7 +36,7 @@ class ApiService {
     const url = `${this.baseUrl}${endpoint}`;
 
     try {
-      const response = await fetch(url, {
+      const response = await fetchWithSession(url, {
         ...options,
         headers: {
           ...this.headers,

--- a/src/utils/fetchWithSession.ts
+++ b/src/utils/fetchWithSession.ts
@@ -1,0 +1,30 @@
+export type FetchWithSessionInit = RequestInit & {
+  headers?: HeadersInit;
+};
+
+const defaultHeaders: HeadersInit = {
+  Accept: 'application/json',
+};
+
+const mergeHeaders = (headers?: HeadersInit): HeadersInit => {
+  const merged = new Headers(defaultHeaders);
+
+  if (headers) {
+    const provided = new Headers(headers);
+    provided.forEach((value, key) => {
+      merged.set(key, value);
+    });
+  }
+
+  return merged;
+};
+
+export const fetchWithSession = (input: RequestInfo | URL, init: FetchWithSessionInit = {}) => {
+  const { headers, ...rest } = init;
+
+  return fetch(input, {
+    ...rest,
+    headers: mergeHeaders(headers),
+    credentials: 'include',
+  });
+};


### PR DESCRIPTION
## Summary
- add a shared `fetchWithSession` helper that always includes session credentials for browser API calls
- update the API service to reuse the helper so requests automatically carry authentication headers
- refactor HubSpot, Harvest, and deals components (including the Sentry sample page) to call the helper instead of raw `fetch`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f8ffc490832f8539048c1b3463c9