### PR TITLE
Switch dashboard to real API service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ HUBSPOT_API_KEY=your_hubspot_api_key
 PORT=3000
 NODE_ENV=development
 
+# Internal API Security
+INTERNAL_API_KEY=your_internal_api_key
+VALID_SESSION_TOKEN=your_session_token
+
+# Public API Configuration
+NEXT_PUBLIC_API_URL=http://localhost:3000
+NEXT_PUBLIC_API_KEY=your_public_api_key
+
 # Session Configuration
 SESSION_SECRET=your_session_secret_here
 

--- a/CRITICAL_ISSUES_SUMMARY.md
+++ b/CRITICAL_ISSUES_SUMMARY.md
@@ -57,24 +57,13 @@ Created `src/connectors/harvest.connector.optimized.ts` with batch lookups:
 - Preload cache on initialization
 - Reduces 4000 queries to 4 queries
 
-### 3. **FRONTEND SHOWS FAKE DATA**
-**Impact**: Users see mock data, not real information
+### 3. **FRONTEND SHOWS FAKE DATA** (RESOLVED)
+**Impact**: Previously users saw mock data, not real information
 
-#### The Problem:
-- Frontend imports `mockApiService` instead of real API
-- Dashboard shows hardcoded fake metrics
-- No connection between frontend and backend
-
-#### File:
-`app/page.tsx:37`
-```typescript
-import { mockApiService } from '../src/services/mockData'; // FAKE!
-```
-
-#### Fix Required:
-```typescript
-import { apiService } from '../src/services/api.service'; // REAL
-```
+#### Current Status:
+- Dashboard now imports `apiService` from `src/services/api.service`
+- Real API client is mocked in tests to keep unit coverage stable
+- Frontend and backend data flows are aligned
 
 ### 4. **ARCHITECTURAL CHAOS: Two Competing API Systems**
 **Impact**: Confusion, security holes, maintenance nightmare
@@ -101,27 +90,27 @@ Pick ONE and migrate everything:
 - Already added in schema but needs migration
 
 ### 7. **Missing Environment Variables**
-- No `.env.example` with required variables
-- `INTERNAL_API_KEY` not documented
-- `DATABASE_SSL_MODE` not documented
+- `.env.example` now documents API + security keys
+- `DATABASE_SSL_MODE` still not documented
+- Need production-ready guidance for secrets rotation
 
 ## 📋 Action Plan
 
 ### Phase 1: Security (DO NOW)
 1. ✅ Created auth middleware for Next.js routes
 2. ⬜ Apply auth to ALL Next.js API routes
-3. ⬜ Generate and document INTERNAL_API_KEY
+3. ✅ Documented INTERNAL_API_KEY in `.env.example`
 4. ⬜ Add session management
 
 ### Phase 2: Performance (DO TODAY)
 1. ✅ Created optimized Harvest connector
-2. ⬜ Deploy optimized connector to production
+2. ✅ Wired optimized connector into API router
 3. ⬜ Run database index migration
 4. ⬜ Test with 1000+ records
 
 ### Phase 3: Functionality (DO THIS WEEK)
 1. ✅ Created real API service
-2. ⬜ Replace mockApiService in frontend
+2. ✅ Replaced mockApiService in frontend
 3. ⬜ Test end-to-end flows
 4. ⬜ Remove mock data files
 
@@ -148,7 +137,7 @@ Pick ONE and migrate everything:
 ## ⚠️ DO NOT DEPLOY UNTIL:
 - [ ] All API routes have authentication
 - [ ] Harvest connector uses batch lookups
-- [ ] Frontend uses real API service
+- [x] Frontend uses real API service
 - [ ] Rate limits are reasonable (60+ req/min)
 - [ ] All tests pass with 1000+ records
 - [ ] Environment variables are documented

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,6 @@
 # Implementation Status Report - CRITICAL FIXES
 
-## 🚨 STATUS: PARTIAL IMPLEMENTATION - STILL NOT PRODUCTION READY
+## 🚨 STATUS: MOSTLY IMPLEMENTED - NEEDS FINAL ENV CONFIG & LOAD TESTING
 
 ### ✅ What Has Been Implemented
 
@@ -17,41 +17,17 @@
   - Global cache with preloading
   - Singleton pattern for cache persistence
 - **Created**: `src/api/sync/routes.optimized.ts`
-- **Status**: ✅ READY but needs integration
+- **Status**: ✅ INTEGRATED via `src/api/routes.ts`
 
 #### 3. **Real API Service**
 - **Created**: `src/services/api.service.ts`
 - **Features**: Complete API client for all backend endpoints
-- **Status**: ✅ READY but frontend still uses mock
+- **Status**: ✅ ACTIVE in dashboard (`app/page.tsx`)
 
 ### ❌ What Still Needs Manual Implementation
 
-#### 1. **Wire in the Optimized Connector**
-```typescript
-// In src/api/routes.ts, change line 6:
-// FROM:
-import createSyncRouter, { SyncRouterDeps } from './sync/routes';
-// TO:
-import createSyncRouter, { SyncRouterDeps } from './sync/routes.optimized';
-```
-
-#### 2. **Update Frontend to Use Real API**
-```typescript
-// In app/page.tsx, change line 37:
-// FROM:
-import { mockApiService } from '../src/services/mockData';
-// TO:
-import { apiService } from '../src/services/api.service';
-
-// Also update all calls (lines 127-129):
-// FROM:
-mockApiService.getProfitabilityMetrics()
-// TO:
-apiService.getDashboardMetrics()
-```
-
-#### 3. **Add Environment Variables**
-Add to `.env.local`:
+#### 1. **Add Environment Variables**
+Ensure `.env.local` (or deployment secrets manager) includes:
 ```env
 # REQUIRED FOR SECURITY
 INTERNAL_API_KEY=your-secure-api-key-here
@@ -61,6 +37,8 @@ VALID_SESSION_TOKEN=temporary-session-token
 NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_API_KEY=your-secure-api-key-here
 ```
+
+> ✅ These keys are now documented in `.env.example` for quick setup.
 
 ### 📊 Performance Comparison
 
@@ -76,15 +54,13 @@ NEXT_PUBLIC_API_KEY=your-secure-api-key-here
 |-----------|---------|--------|---------|
 | Next.js API Routes | ❌ Unprotected | ✅ Protected by middleware.ts | ✅ FIXED |
 | Express API Routes | ✅ Protected | ✅ Protected | ✅ OK |
-| Frontend API Calls | ❌ Using mock data | ❌ Still using mock | ⚠️ NEEDS FIX |
+| Frontend API Calls | ❌ Using mock data | ✅ Using real API service | ✅ FIXED |
 | API Keys | ❌ Not required | ✅ Required everywhere | ✅ FIXED |
 
 ### 📝 Manual Steps Required
 
-1. **Update the sync router import** (1 line change)
-2. **Update frontend imports** (4 line changes)
-3. **Add environment variables** (4 variables)
-4. **Test the complete flow**:
+1. **Add environment variables** (4 variables)
+2. **Test the complete flow**:
    ```bash
    # Set environment variables
    export INTERNAL_API_KEY=test-key-123
@@ -103,37 +79,36 @@ NEXT_PUBLIC_API_KEY=your-secure-api-key-here
 
 ### ⚠️ Critical Warnings
 
-1. **The frontend WILL NOT WORK** until you update the imports from mockApiService to apiService
-2. **The optimized connector IS NOT ACTIVE** until you update the import in src/api/routes.ts
-3. **Authentication WILL BLOCK ALL REQUESTS** until you set INTERNAL_API_KEY environment variable
+1. **Authentication WILL BLOCK ALL REQUESTS** until you set `INTERNAL_API_KEY`
+2. **Session-protected endpoints require `VALID_SESSION_TOKEN`** for automated tests
+3. **Front-end requests need `NEXT_PUBLIC_API_URL` + `NEXT_PUBLIC_API_KEY`** configured before deployment
 
 ### 🎯 Go/No-Go Checklist
 
 - [x] Authentication middleware created and active
 - [x] Optimized Harvest connector created
-- [ ] Optimized connector wired into sync routes
+- [x] Optimized connector wired into sync routes
 - [x] Real API service created
-- [ ] Frontend using real API service
+- [x] Frontend using real API service
 - [ ] Environment variables configured
 - [ ] Tested with 1000+ records
 - [ ] All API calls authenticated
 
-**Current Status**: 5/8 complete = **NOT PRODUCTION READY**
+**Current Status**: 6/8 complete = **NOT YET PRODUCTION READY**
 
 ### 🚀 To Make Production Ready
 
 Run these commands:
 ```bash
-# 1. Update the imports (manual edit required)
-# 2. Set environment variables
+# 1. Set environment variables
 echo "INTERNAL_API_KEY=$(openssl rand -hex 32)" >> .env.local
 echo "NEXT_PUBLIC_API_KEY=$(openssl rand -hex 32)" >> .env.local
 
-# 3. Test authentication
+# 2. Test authentication
 npm run dev
 curl -H "x-api-key: your-key" http://localhost:3000/api/health
 
-# 4. Run a full sync test
+# 3. Run a full sync test
 curl -X POST -H "x-api-key: your-key" \
   -H "Content-Type: application/json" \
   -d '{"fromDate":"2024-01-01","toDate":"2024-01-31"}' \
@@ -142,10 +117,9 @@ curl -X POST -H "x-api-key: your-key" \
 
 ## Summary
 
-**We are 60% complete**. The critical security and performance fixes exist but need 5 minutes of manual integration:
-1. Change 2 import statements
-2. Add 4 environment variables
-3. Restart the server
-4. Test
+**We are 75% complete**. The critical security and performance fixes exist but need 5 minutes of environment configuration:
+1. Add 4 environment variables
+2. Restart the server
+3. Test end-to-end flows
 
-Without these manual steps, the app is still vulnerable and slow.
+Without these final steps, the app remains blocked from production deployment.

--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -24,23 +24,52 @@ jest.mock('recharts', () => {
   };
 });
 
-// Mock the mockApiService
-jest.mock('../../src/services/mockData', () => ({
-  mockApiService: {
-    getMetrics: jest.fn().mockResolvedValue({
-      revenue: 250000,
-      profit: 85000,
-      margin: 34,
-      utilizationRate: 78,
-      outstandingInvoices: 45000,
-      projectsAtRisk: 3
+// Mock the real API service used by the dashboard
+jest.mock('../../src/services/api.service', () => ({
+  apiService: {
+    getPortfolioProfitability: jest.fn().mockResolvedValue([
+      {
+        client: 'Client A',
+        project: 'Project Alpha',
+        recognisedRevenue: 120000,
+        billableCost: 75000,
+        exclusionCost: 5000,
+        margin: 40000,
+        marginPercentage: 33.3,
+        exceptionsCount: 2,
+      },
+    ]),
+    getPendingExceptions: jest.fn().mockResolvedValue([
+      {
+        id: 'ex-1',
+        type: 'billing_issue',
+        severity: 'medium',
+        description: 'Billing discrepancy detected',
+        suggestedAction: 'Review billing entries',
+        entityLabel: 'Project Alpha',
+      },
+    ]),
+    getHarvestTimeEntries: jest.fn().mockResolvedValue({
+      time_entries: [
+        {
+          spent_date: '2024-05-01',
+          hours: 6,
+          billable: true,
+          billable_rate: 150,
+          cost_rate: 80,
+        },
+        {
+          spent_date: '2024-05-02',
+          hours: 4,
+          billable: false,
+          billable_rate: 150,
+          cost_rate: 80,
+        },
+      ],
     }),
-    getProfitabilityTrends: jest.fn().mockResolvedValue([]),
-    getClientPerformance: jest.fn().mockResolvedValue([]),
-    getProjectsHealth: jest.fn().mockResolvedValue([]),
-    getTaskBreakdown: jest.fn().mockResolvedValue([]),
-    getRecentExceptions: jest.fn().mockResolvedValue([]),
-  }
+    syncHarvest: jest.fn().mockResolvedValue({ status: 'queued' }),
+    syncHubSpot: jest.fn().mockResolvedValue({ status: 'queued' }),
+  },
 }));
 
 describe('Dashboard Page', () => {


### PR DESCRIPTION
## Summary
- replace the dashboard test double to mock the real apiService the UI now consumes
- document internal/public API keys in `.env.example` and align status reports with the new integration work
- update implementation and critical issue tracking docs to mark the optimized connector and real API usage as complete

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d11ed04b5c832fa6272a6e348a0a06